### PR TITLE
:rocket: Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv*
 .cache_datasets/
+*.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/plotly_resampler/__init__.py
+++ b/plotly_resampler/__init__.py
@@ -10,7 +10,7 @@ from .downsamplers import LTTB, EveryNthPoint, AggregationDownsampler
 
 __docformat__ = "numpy"
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __pdoc__ = {}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1527,7 +1527,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "trace-updater"
-version = "0.0.5"
+version = "0.0.6"
 description = "Dash component which allows to update a dcc.Graph its traces. This component is data efficient as it (1) only sends the to-be-updated traces (and not the whole) from the back-end to the client-side and (2) only updates the traces that have changed (and does not redraw the whole figure)."
 category = "main"
 optional = false
@@ -1687,7 +1687,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f8e86114f2cdc3db3b51c96d88a0a31f8bacf4749b1a07e2ac67377056e9098e"
+content-hash = "b3ab86845725d444bd12106d9e22c42dd80c951293d0ca7b1d0d67fe97350c8d"
 
 [metadata.files]
 ansi2html = [
@@ -2341,7 +2341,6 @@ numpy = [
 ]
 orjson = [
     {file = "orjson-3.6.4-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:fc01a15f3101628fd619158daec79b30d7461149735e73542ca8c13be6b835be"},
-    {file = "orjson-3.6.4-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:c840e6ca222f76e7f13e9ee2f0650c9ee449e5e4aae38c73ab6ecaf3077ea21c"},
     {file = "orjson-3.6.4-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:48a69fed90f551bf9e9bb7a63e363fed4f67fc7c6e6bfb057054dc78f6721e9e"},
     {file = "orjson-3.6.4-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:3722f02f50861d5e2a6be9d50bfe8da27a5155bb60043118a4e1ceb8c7040cf7"},
     {file = "orjson-3.6.4-cp310-none-win_amd64.whl", hash = "sha256:231a99a728322d0271e970b149c57deb67315e6837e6cd4166cf51d30161700c"},
@@ -2412,7 +2411,6 @@ pathspec = [
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 pdoc3 = [
-    {file = "pdoc3-0.10.0-py3-none-any.whl", hash = "sha256:ba45d1ada1bd987427d2bf5cdec30b2631a3ff5fb01f6d0e77648a572ce6028b"},
     {file = "pdoc3-0.10.0.tar.gz", hash = "sha256:5f22e7bcb969006738e1aa4219c75a32f34c2d62d46dc9d2fb2d3e0b0287e4b7"},
 ]
 pexpect = [
@@ -2764,8 +2762,8 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 trace-updater = [
-    {file = "trace_updater-0.0.5-py3-none-any.whl", hash = "sha256:ade27c8ba29d86950471d3bcf5db6886c8fce76be5abd3e4663c7194450d0534"},
-    {file = "trace_updater-0.0.5.tar.gz", hash = "sha256:e98f87664ba1d3cc9ce5ff4e4591138dd5bb623f09ddff9eb11fbc0643ad673e"},
+    {file = "trace_updater-0.0.6-py3-none-any.whl", hash = "sha256:217ce1b3d799d6aabdd088bdd1215012a9416ab0f8da715f1330f9b34d823bd3"},
+    {file = "trace_updater-0.0.6.tar.gz", hash = "sha256:efa222a25c5d83254a755cd1f3a8bb33123bdcf1f12bafcd1fb36f0c51be23c7"},
 ]
 traitlets = [
     {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plotly-resampler"  # Do not forget to update the __init__.py __version__ variable
-version = "0.2.2"
+version = "0.2.3"
 description = "Visualizing large time series with plotly"
 authors = ["Jonas Van Der Donckt", "Jeroen Van Der Donckt", "Emiel Deprost"]
 readme = "README.md"
@@ -16,7 +16,7 @@ plotly = "^5.3.1"
 dash = "^2.0.0"
 lttbc = "^0.2.0"
 orjson = "^3.6.4"
-trace-updater = "^0.0.5"
+trace-updater = "^0.0.6"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = "^3.2.0"


### PR DESCRIPTION
Updates the .gitignore and update depencies to https://github.com/predict-idlab/trace-updater/pull/1.