### PR TITLE
:bug: assert dimensionality of high-frequency traces

### DIFF
--- a/plotly_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler.py
@@ -388,6 +388,9 @@ class FigureResampler(go.Figure):
                 return ts.tz_localize(None)
             return ts
 
+        if t_start is not None and t_stop is not None:
+            assert t_start.tz == t_stop.tz
+
         return hf_series[to_same_tz(t_start) : to_same_tz(t_stop)]
 
     def add_trace(

--- a/plotly_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler.py
@@ -528,7 +528,7 @@ class FigureResampler(go.Figure):
             # Remove NaNs for efficiency (storing less meaningless data)
             # NaNs introduce gaps between enclosing non-NaN data points & might distort
             # the resampling algorithms
-            if pd.isna(hf_y).any():
+            if pd.isna(hf_y).any() and hf_y.ndim == 1:
                 not_nan_mask = ~pd.isna(hf_y)
                 hf_x = hf_x[not_nan_mask]
                 hf_y = hf_y[not_nan_mask]
@@ -546,8 +546,8 @@ class FigureResampler(go.Figure):
             if str(hf_y.dtype) in ["uint8", "uint16"]:
                 hf_y = hf_y.astype("uint32")
 
-            assert len(hf_x) > 0
-            assert len(hf_x) == len(hf_y)
+            assert len(hf_x) > 0, "No data to plot!"
+            assert len(hf_x) == len(hf_y), "x and y have different length!"
 
             # Convert the hovertext to a pd.Series if it's now a np.ndarray
             # Note: The size of hovertext must be the same size as hf_x otherwise a

--- a/plotly_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler.py
@@ -516,6 +516,13 @@ class FigureResampler(go.Figure):
 
         high_frequency_traces = ["scatter", "scattergl"]
         if trace["type"].lower() in high_frequency_traces:
+            # When the x or y of a trace has more than 1 dimension, it is not at all
+            # straightforward how it should be resampled.
+            assert hf_y.ndim == 1 and np.ndim(hf_x) == 1, (
+                "plotly-resampler requires scatter data "
+                "(i.e., x and y, or hf_x and hf_y) to be 1 dimensional!"
+            )
+
             # Make sure to set the text-attribute to None as the default plotly behavior
             # for these high-dimensional traces (scatters) is that text will be shown in
             # hovertext and not in on-graph texts (as is the case with bar-charts)
@@ -528,7 +535,7 @@ class FigureResampler(go.Figure):
             # Remove NaNs for efficiency (storing less meaningless data)
             # NaNs introduce gaps between enclosing non-NaN data points & might distort
             # the resampling algorithms
-            if pd.isna(hf_y).any() and hf_y.ndim == 1:
+            if pd.isna(hf_y).any():
                 not_nan_mask = ~pd.isna(hf_y)
                 hf_x = hf_x[not_nan_mask]
                 hf_y = hf_y[not_nan_mask]


### PR DESCRIPTION
Eventually settled for asserting that high-frequency traces (i.e., `x` and `y` or `hf_x` and `hf_y`) are 1 dimensional.

This is slightly different behavior from plotly (where this is supported, but gives rather unexpected plots). Supporting this would (1) require us to change our internal structure (as we store `hf_series` internally: explicitly 1D data) while (2) most-likely enabling weird / unexpected plots.

Example of a weird / unexpected plot
```py
import pandas as pd
import numpy as np
import plotly.graph_objects as go

df = pd.DataFrame(index=np.arange(100), data={"a": np.arange(100)})

## PLOTLY
fig = go.Figure()
fig.add_trace(
    go.Scatter(
        x=df.index,
        y=df[["a"]],  # (100, 1) shape
    )
)
fig.show()
```

![image](https://user-images.githubusercontent.com/18898740/157537637-82bc8531-32e1-4c10-9000-30157d2ae340.png)

If we wrap `fig` with plotly-resampler its `FigureResampler` an AssertionError will be thrown now.

(In #33 we tried to fix this ourselves by calling `.squeeze()`, but I believe it should be the end-user its responsibility to handle this)