### PR TITLE
:recycle: comply with new pandas index handling

### DIFF
--- a/plotly_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler.py
@@ -186,7 +186,7 @@ class FigureResampler(go.Figure):
                 hf_series: pd.Series = hf_trace_data["hf_series"]
                 start = hf_series.index[0] if start is None else start
                 end = hf_series.index[-1] if end is None else end
-                if isinstance(hf_series.index, (pd.Int64Index, pd.UInt64Index)):
+                if hf_series.index.is_integer():
                     start = round(start)
                     end = round(end)
 
@@ -516,7 +516,7 @@ class FigureResampler(go.Figure):
             if isinstance(hf_y, pd.Series)
             else hf_y
         )
-        hf_y = np.asarray(hf_y)
+        # hf_y = np.asarray(hf_y)
 
         # Note: "hovertext" takes precedence over "text"
         hf_hovertext = (

--- a/plotly_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler.py
@@ -293,7 +293,7 @@ class FigureResampler(go.Figure):
             xaxis_filter_short = "x" + xaxis_filter.lstrip("xaxis")
 
         if updated_trace_indices is None:
-            updated_trace_indices = [] 
+            updated_trace_indices = []
 
         for idx, trace in enumerate(figure["data"]):
             # We skip when the trace-idx already has been updated.
@@ -516,7 +516,7 @@ class FigureResampler(go.Figure):
             if isinstance(hf_y, pd.Series)
             else hf_y
         )
-        # hf_y = np.asarray(hf_y)
+        hf_y = np.asarray(hf_y)
 
         # Note: "hovertext" takes precedence over "text"
         hf_hovertext = (


### PR DESCRIPTION
This PR solves issue #36 

Note: I benchmarked `.is_integer` vs the current `isinstance` checking. My findings are that `.is_integer` is slightly slower, but this is a constant (minor) difference, meaning that just like for type checking the runtime does not deteriorate for longer index lengths.

![image](https://user-images.githubusercontent.com/18898740/158999920-70b9e73e-f03c-495d-b094-9539cc588817.png)
