### PR TITLE
🗳️ Compose figs

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -22,7 +22,7 @@ from trace_updater import TraceUpdater
 
 from ..aggregation import AbstractSeriesAggregator, EfficientLTTB
 from .figure_resampler_interface import AbstractFigureAggregator
-from .utils import is_figure, is_fwr, is_fr
+from .utils import is_figure, is_fwr
 
 
 class FigureResampler(AbstractFigureAggregator, go.Figure):

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -73,13 +73,13 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         if isinstance(figure, AbstractFigureAggregator):
             # Copy the `_hf_data` if the previous figure was an AbstractFigureAggregator
             # and adjust the default `max_n_samples` and `downsampler`
-            self._hf_data = self._copy_hf_data(
-                figure._hf_data, adjust_default_values=True
+            self._hf_data.update(
+                self._copy_hf_data(figure._hf_data, adjust_default_values=True)
             )
 
             # Note: This hack ensures that the this figure object initially uses
-            # data of the whole view. More concretely; we create a dict 
-            # serialization figure and adjust the hf-traces to the whole view 
+            # data of the whole view. More concretely; we create a dict
+            # serialization figure and adjust the hf-traces to the whole view
             # with the check-update method (by passing no range / filter args)
             with self.batch_update():
                 graph_dict: dict = self._get_current_graph()

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -42,7 +42,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         verbose: bool = False,
     ):
         # Parse the figure input before calling `super`
-        if is_figure(figure) and not is_fr(figure):
+        if is_figure(figure) and not is_fr(figure):  # go.Figure
             # Base case, the figure does not need to be adjusted
             f = figure
         else:
@@ -51,7 +51,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             f = go.Figure()
             f._data_validator.set_uid = False
 
-            if isinstance(figure, BaseFigure):
+            if isinstance(figure, BaseFigure):  # go.FigureWidget or AbstractFigureAggregator
                 # A base figure object, we first copy the layout and grid ref
                 f.layout = figure.layout
                 f._grid_ref = figure._grid_ref

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -107,10 +107,27 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
             # make sure that the UIDs of these traces do not get adjusted
             self._data_validator.set_uid = False
-            self.add_traces(list(figure.data))
+            self.add_traces(figure.data)
         else:
             super().__init__(figure)
             self._data_validator.set_uid = False
+
+        # A list of al xaxis and yaxis string names
+        # e.g., "xaxis", "xaxis2", "xaxis3", .... for _xaxis_list
+        self._xaxis_list = self._re_matches(re.compile("xaxis\d*"), self._layout.keys())
+        self._yaxis_list = self._re_matches(re.compile("yaxis\d*"), self._layout.keys())
+        # edge case: an empty `go.Figure()` does not yet contain axes keys
+        if not len(self._xaxis_list):
+            self._xaxis_list = ["xaxis"]
+            self._yaxis_list = ["yaxis"]
+
+        # Make sure to reset the layout its range
+        self.update_layout(
+            {
+                axis: {"autorange": True, "range": None}
+                for axis in self._xaxis_list + self._yaxis_list
+            }
+        )
 
     def _print(self, *values):
         """Helper method for printing if ``verbose`` is set to True."""
@@ -651,7 +668,12 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         return _hf_data_container(hf_x, hf_y, hf_text, hf_hovertext)
 
     def _construct_hf_data_dict(
-        self, dc, trace, downsampler, max_n_samples: int, offset=0
+        self,
+        dc,
+        trace,
+        downsampler: AbstractSeriesAggregator | None,
+        max_n_samples: int | None,
+        offset=0,
     ) -> dict:
         """Create the `hf_data` dict item which will be put in the `_hf_data` property.
 
@@ -661,9 +683,9 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             The hf_data container, withholding the parsed hf-data
         trace : BaseTraceType
             The trace.
-        downsampler : AbstractSeriesAggregator
+        downsampler : AbstractSeriesAggregator | None
             The downsampler which will be used.
-        max_n_samples : int
+        max_n_samples : int | None
             The max number of output samples.
 
         Returns
@@ -690,13 +712,25 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         # & (3) store a hf_data entry for the corresponding trace,
         # identified by its UUID
         axis_type = "date" if isinstance(dc.x, pd.DatetimeIndex) else "linear"
-        d = self._global_downsampler if downsampler is None else downsampler
+
+        default_n_samples = False
+        if max_n_samples is None:
+            default_n_samples = True
+            max_n_samples = self._global_n_shown_samples
+
+        default_downsampler = False
+        if downsampler is None:
+            default_downsampler = True
+            downsampler = self._global_downsampler
+
         return {
             "max_n_samples": max_n_samples,
+            "default_n_samples": default_n_samples,
             "x": dc.x,
             "y": dc.y,
             "axis_type": axis_type,
-            "downsampler": d,
+            "downsampler": downsampler,
+            "default_downsampler": default_downsampler,
             "text": dc.text,
             "hovertext": dc.hovertext,
         }
@@ -813,8 +847,9 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         if isinstance(trace, (list, tuple)):
             raise ValueError("Trace must be either a dict or a BaseTraceType")
 
-        if max_n_samples is None:
-            max_n_samples = self._global_n_shown_samples
+        max_out_s = (
+            self._global_n_shown_samples if max_n_samples is None else max_n_samples
+        )
 
         # Validate the trace and convert to a trace object
         if not isinstance(trace, BaseTraceType):
@@ -831,9 +866,9 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         # These traces will determine the autoscale RANGE!
         #   -> so also store when `limit_to_view` is set.
         if trace["type"].lower() in self._high_frequency_traces:
-            if n_samples > max_n_samples or limit_to_view:
+            if n_samples > max_out_s or limit_to_view:
                 self._print(
-                    f"\t[i] DOWNSAMPLE {trace['name']}\t{n_samples}->{max_n_samples}"
+                    f"\t[i] DOWNSAMPLE {trace['name']}\t{n_samples}->{max_out_s}"
                 )
 
                 self._hf_data[uuid_str] = self._construct_hf_data_dict(
@@ -926,7 +961,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
                 `Figure.add_traces <https://plotly.com/python-api-reference/generated/plotly.graph_objects.Figure.html#plotly.graph_objects.Figure.add_traces>`_ docs.
 
         """
-        # note: Plotly its add_traces also a allows non list-like input e.g. a scatter 
+        # note: Plotly its add_traces also a allows non list-like input e.g. a scatter
         # object; the code below is an exact copy of their internally applied parsing
         if not isinstance(data, (list, tuple)):
             data = [data]
@@ -938,6 +973,12 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             else trace
             for trace in data
         ]
+
+        # First add an UUID, as each (even the non-hf_data traces), must contain this
+        # key for comparison, if the trace already has an UUID, we will keep it.
+        for trace in data:
+            uuid_str = str(uuid4()) if trace.uid is None else trace.uid
+            trace.uid = uuid_str
 
         # Convert the data properties
         if isinstance(max_n_samples, (int, np.integer)) or max_n_samples is None:
@@ -956,20 +997,17 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             ):
                 continue
 
-            max_out = self._global_n_shown_samples if max_out is None else max_out
-            if not limit_to_view and (trace.y is None or len(trace.y) <= max_out):
+            max_out_s = self._global_n_shown_samples if max_out is None else max_out
+            if not limit_to_view and (trace.y is None or len(trace.y) <= max_out_s):
                 continue
 
-            d = self._global_downsampler if downsampler is None else downsampler
-
-            # First add an UUID, as each (even the non-hf_data traces), must contain this
-            # key for comparison, if the trace already has an UUID, we will keep it.
-            uuid_str = str(uuid4()) if trace.uid is None else trace.uid
-            trace.uid = uuid_str
-
             dc = self._parse_get_trace_props(trace)
-            self._hf_data[uuid_str] = self._construct_hf_data_dict(
-                dc, trace=trace, downsampler=d, max_n_samples=max_out, offset=i
+            self._hf_data[trace.uid] = self._construct_hf_data_dict(
+                dc,
+                trace=trace,
+                downsampler=downsampler,
+                max_n_samples=max_out,
+                offset=i,
             )
 
             trace = trace._props  # convert the trace into a dict
@@ -988,6 +1026,41 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         self._data = []
         self._layout = {}
         self.layout = {}
+
+    def _copy_hf_data(self, hf_data: dict, adjust_default_values: bool = False) -> dict:
+        """Copy (i.e. create a new key reference, not a deep copy) of a hf_data dict.
+
+        Parameters
+        ----------
+        hf_data : dict
+            The hf_data dict, having the trace 'uid' as key and the
+            hf-data, together with its aggregation properties as dict-values
+        adjust_default_values: bool
+            Whether the default values (of the downsampler, max # shown samples) will
+            be adjusted according to the values of this object, by default False
+
+        Returns
+        -------
+        dict
+            The copied (& default values adjusted) output dict.
+
+        """
+        hf_data_cp = {
+            k: {
+                k_: hf_data[k][k_]
+                for k_ in set(v.keys())  # .difference(_hf_data_container._fields)
+            }
+            for k, v in hf_data.items()
+        }
+
+        if adjust_default_values:
+            for hf_props in hf_data_cp.values():
+                if hf_props.get("default_downsampler", False):
+                    hf_props["downsampler"] = self._global_downsampler
+                if hf_props.get("default_n_samples", False):
+                    hf_props["max_n_samples"] = self._global_n_shown_samples
+
+        return hf_data_cp
 
     def replace(self, figure: go.Figure, convert_existing_traces: bool = True):
         """Replace the current figure layout with the passed figure object.

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -675,7 +675,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         max_n_samples: int | None,
         offset=0,
     ) -> dict:
-        """Create the `hf_data` dict item which will be put in the `_hf_data` property.
+        """Create the `hf_data` dict which will be put in the `_hf_data` property.
 
         Parameters
         ----------
@@ -695,7 +695,6 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         """
         # We will re-create this each time as hf_x and hf_y withholds
         # high-frequency data
-        # index = pd.Index(hf_x, copy=False, name="timestamp")
         hf_series = self._to_hf_series(x=dc.x, y=dc.y)
 
         # Checking this now avoids less interpretable `KeyError` when resampling
@@ -856,7 +855,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             trace = self._data_validator.validate_coerce(trace)[0]
 
         # First add an UUID, as each (even the non-hf_data traces), must contain this
-        # key for comparison, if the trace already has an UUID, we will keep it.
+        # key for comparison. If the trace already has an UUID, we will keep it.
         uuid_str = str(uuid4()) if trace.uid is None else trace.uid
         trace.uid = uuid_str
 
@@ -976,7 +975,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         ]
 
         # First add an UUID, as each (even the non-hf_data traces), must contain this
-        # key for comparison, if the trace already has an UUID, we will keep it.
+        # key for comparison. If the trace already has an UUID, we will keep it.
         for trace in data:
             uuid_str = str(uuid4()) if trace.uid is None else trace.uid
             trace.uid = uuid_str

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -919,7 +919,8 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         .. note::
             make sure to look at the :func:`add_trace` function for more info about
-            **speed optimization**, and dealing with not
+            **speed optimization**, and dealing with not ``high-frequency`` data, but 
+            still want to resample / limit the data to the front-end view.
 
         Parameters
         ----------

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -79,13 +79,13 @@ class FigureWidgetResampler(
         if isinstance(figure, AbstractFigureAggregator):
             # Copy the `_hf_data` if the previous figure was an AbstractFigureAggregator
             # And adjust the default max_n_samples and
-            self._hf_data = self._copy_hf_data(
-                figure._hf_data, adjust_default_values=True
+            self._hf_data.update(
+                self._copy_hf_data(figure._hf_data, adjust_default_values=True)
             )
 
             # Note: This hack ensures that the this figure object initially uses
-            # data of the whole view. More concretely; we create a dict 
-            # serialization figure and adjust the hf-traces to the whole view 
+            # data of the whole view. More concretely; we create a dict
+            # serialization figure and adjust the hf-traces to the whole view
             # with the check-update method (by passing no range / filter args)
             with self.batch_update():
                 graph_dict: dict = self._get_current_graph()

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -18,7 +18,7 @@ import plotly.graph_objects as go
 from .figure_resampler_interface import AbstractFigureAggregator
 from ..aggregation import AbstractSeriesAggregator, EfficientLTTB
 from plotly.basedatatypes import BaseFigure
-from plotly_resampler.figure_resampler.utils import is_figurewidget, is_fr, is_fwr
+from plotly_resampler.figure_resampler.utils import is_figurewidget
 
 
 class _FigureWidgetResamplerM(type(AbstractFigureAggregator), type(go.FigureWidget)):

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -13,10 +13,10 @@ __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 from typing import Tuple
 
 import plotly.graph_objects as go
-
-from .figure_resampler_interface import AbstractFigureAggregator
-from ..aggregation import AbstractSeriesAggregator, EfficientLTTB
 from plotly.basedatatypes import BaseFigure
+
+from ..aggregation import AbstractSeriesAggregator, EfficientLTTB
+from .figure_resampler_interface import AbstractFigureAggregator
 
 
 class _FigureWidgetResamplerM(type(AbstractFigureAggregator), type(go.FigureWidget)):
@@ -51,16 +51,14 @@ class FigureWidgetResampler(
         show_mean_aggregation_size: bool = True,
         verbose: bool = False,
     ):
-
         # Parse the figure input before calling `super`
         f = go.FigureWidget()
         f._data_validator.set_uid = False
 
-        if isinstance(figure, BaseFigure):
+        if isinstance(figure, BaseFigure):  # go.Figure or go.FigureWidget or AbstractFigureAggregator
             # A base figure object, we first copy the layout and grid ref
             f.layout = figure.layout
             f._grid_ref = figure._grid_ref
-
             f.add_traces(figure.data)
         elif isinstance(figure, (dict, list)):
             # A single trace dict or a list of traces

--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -12,7 +12,7 @@ from typing import Any
 
 
 def is_figure(figure: Any) -> bool:
-    """Check if the figure is a plotly go.Figure.
+    """Check if the figure is a plotly go.Figure or a FigureResampler.
 
     .. Note::
         This method does not use isinstance(figure, go.Figure) as this will not work
@@ -27,60 +27,14 @@ def is_figure(figure: Any) -> bool:
     Returns
     -------
     bool
-        True if the figure is a plotly go.Figure.
+        True if the figure is a plotly go.Figure or a FigureResampler.
     """
 
     return isinstance(figure, BaseFigure) and (not isinstance(figure, BaseFigureWidget))
 
 
-def is_fr(figure: Any) -> bool:
-    """Check if the figure is a plotly FigureResampler.
-
-    .. Note::
-        This method does not use isinstance(figure, go.Figure) as this will not work
-        when go.Figure is decorated (after executing the
-        ``register_plotly_resampler`` function).
-
-    Parameters
-    ----------
-    figure : Any
-        The figure to check.
-
-    Returns
-    -------
-    bool
-        True if the figure is a plotly go.Figure.
-    """
-    from plotly_resampler import FigureResampler
-
-    return isinstance(figure, FigureResampler)
-
-
-def is_fwr(figure: Any) -> bool:
-    """Check if the figure is a plotly FigureWidgetResampler.
-
-    .. Note::
-        This method does not use isinstance(figure, go.Figure) as this will not work
-        when go.Figure is decorated (after executing the
-        ``register_plotly_resampler`` function).
-
-    Parameters
-    ----------
-    figure : Any
-        The figure to check.
-
-    Returns
-    -------
-    bool
-        True if the figure is a plotly go.Figure.
-    """
-    from plotly_resampler import FigureWidgetResampler
-
-    return isinstance(figure, FigureWidgetResampler)
-
-
 def is_figurewidget(figure: Any):
-    """Check if the figure is a plotly go.FigureWidget.
+    """Check if the figure is a plotly go.FigureWidget or a FigureWidgetResampler.
 
     .. Note::
         This method does not use isinstance(figure, go.FigureWidget) as this will not
@@ -95,9 +49,51 @@ def is_figurewidget(figure: Any):
     Returns
     -------
     bool
-        True if the figure is a plotly go.FigureWidget.
+        True if the figure is a plotly go.FigureWidget or a FigureWidgetResampler.
     """
     return isinstance(figure, BaseFigureWidget)
+
+
+def is_fr(figure: Any) -> bool:
+    """Check if the figure is a FigureResampler.
+
+    .. Note::
+        This method will not return True if the figure is a plotly go.Figure.
+
+    Parameters
+    ----------
+    figure : Any
+        The figure to check.
+
+    Returns
+    -------
+    bool
+        True if the figure is a FigureResampler.
+    """
+    from plotly_resampler import FigureResampler
+
+    return isinstance(figure, FigureResampler)
+
+
+def is_fwr(figure: Any) -> bool:
+    """Check if the figure is a FigureWidgetResampler.
+
+    .. Note::
+        This method will not return True if the figure is a plotly go.FigureWidget.
+
+    Parameters
+    ----------
+    figure : Any
+        The figure to check.
+
+    Returns
+    -------
+    bool
+        True if the figure is a FigureWidgetResampler.
+    """
+    from plotly_resampler import FigureWidgetResampler
+
+    return isinstance(figure, FigureWidgetResampler)
 
 
 ### Rounding functions for bin size

--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for the figure_resampler submodule."""
+
 import math
 import pandas as pd
 
@@ -14,7 +16,7 @@ def is_figure(figure: Any) -> bool:
 
     .. Note::
         This method does not use isinstance(figure, go.Figure) as this will not work
-        when go.Figure is decorated (after executing the the 
+        when go.Figure is decorated (after executing the
         ``register_plotly_resampler`` function).
 
     Parameters
@@ -31,12 +33,58 @@ def is_figure(figure: Any) -> bool:
     return isinstance(figure, BaseFigure) and (not isinstance(figure, BaseFigureWidget))
 
 
+def is_fr(figure: Any) -> bool:
+    """Check if the figure is a plotly FigureResampler.
+
+    .. Note::
+        This method does not use isinstance(figure, go.Figure) as this will not work
+        when go.Figure is decorated (after executing the
+        ``register_plotly_resampler`` function).
+
+    Parameters
+    ----------
+    figure : Any
+        The figure to check.
+
+    Returns
+    -------
+    bool
+        True if the figure is a plotly go.Figure.
+    """
+    from plotly_resampler import FigureResampler
+
+    return isinstance(figure, FigureResampler)
+
+
+def is_fwr(figure: Any) -> bool:
+    """Check if the figure is a plotly FigureWidgetResampler.
+
+    .. Note::
+        This method does not use isinstance(figure, go.Figure) as this will not work
+        when go.Figure is decorated (after executing the
+        ``register_plotly_resampler`` function).
+
+    Parameters
+    ----------
+    figure : Any
+        The figure to check.
+
+    Returns
+    -------
+    bool
+        True if the figure is a plotly go.Figure.
+    """
+    from plotly_resampler import FigureWidgetResampler
+
+    return isinstance(figure, FigureWidgetResampler)
+
+
 def is_figurewidget(figure: Any):
     """Check if the figure is a plotly go.FigureWidget.
 
     .. Note::
         This method does not use isinstance(figure, go.FigureWidget) as this will not
-        work when go.FigureWidget is decorated (after executing the the
+        work when go.FigureWidget is decorated (after executing the
         ``register_plotly_resampler`` function).
 
     Parameters
@@ -104,6 +152,11 @@ def timedelta_to_str(td: pd.Timedelta) -> str:
 
 
 def round_td_str(td: pd.Timedelta) -> str:
+    """Round a timedelta to the nearest unit and convert to a string.
+
+    .. seealso::
+        :func:`timedelta_to_str`
+    """
     for t_s in ["D", "H", "min", "s", "ms", "us", "ns"]:
         if td > 0.95 * pd.Timedelta(f"1{t_s}"):
             return timedelta_to_str(td.round(t_s))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,20 +47,28 @@ def driver():
 @pytest.fixture
 def float_series() -> pd.Series:
     x = np.arange(_nb_samples).astype(np.uint32)
-    y = np.sin(x / 300).astype(np.float32) + np.random.randn(_nb_samples) / 5
+    y = np.sin(x / 50).astype(np.float32) + np.random.randn(_nb_samples) / 5
     return pd.Series(index=x, data=y)
 
 
 @pytest.fixture
 def cat_series() -> pd.Series:
-    cats_list = ["a", "b", "b", "b", "c", "c", "a", "d", "a"]
-    return pd.Series(cats_list * (_nb_samples // len(cats_list)), dtype="category")
+    cats_list = ["a", "a", "a", "a"] * 2000
+    for i in np.random.randint(0, len(cats_list), 3):
+        cats_list[i] = "b"
+    for i in np.random.randint(0, len(cats_list), 3):
+        cats_list[i] = "c"
+    return pd.Series(cats_list * (_nb_samples // len(cats_list) + 1), dtype="category")[
+        :_nb_samples
+    ]
 
 
 @pytest.fixture
 def bool_series() -> pd.Series:
-    bool_list = [True, False, True, True, True, True] + [True] * 50
-    return pd.Series(bool_list * (_nb_samples // len(bool_list)), dtype="bool")
+    bool_list = [True, False, True, True, True, True] + [True] * 1000
+    return pd.Series(bool_list * (_nb_samples // len(bool_list) + 1), dtype="bool")[
+        :_nb_samples
+    ]
 
 
 @pytest.fixture
@@ -285,7 +293,7 @@ def gsr_figure() -> FigureResampler:
             ' <b style="color:red">[R]</b>',
         ),
         verbose=False,
-        show_mean_aggregation_size=True
+        show_mean_aggregation_size=True,
     )
     fig.update_layout(height=700)
 
@@ -410,7 +418,7 @@ def cat_series_box_hist_figure() -> FigureResampler:
 
     fig.add_trace(go.Box(x=float_series.values, name="float_series"), row=1, col=2)
     fig.add_trace(
-        go.Box(x=float_series.values ** 2, name="float_series**2"), row=1, col=2
+        go.Box(x=float_series.values**2, name="float_series**2"), row=1, col=2
     )
 
     # add a not hf-trace

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -88,7 +88,7 @@ def test_every_nth_point_bool_sequence_data(bool_series):
 
 
 def test_every_nth_point_empty_series():
-    empty_series = pd.Series(name="empty")
+    empty_series = pd.Series(name="empty", dtype='float32')
     out = EveryNthPoint(interleave_gaps=True).aggregate(empty_series, n_out=1_000)
     assert out.equals(empty_series)
 
@@ -230,7 +230,7 @@ def test_mmo_bool_sequence_data(bool_series):
 
 
 def test_mmo_empty_series():
-    empty_series = pd.Series(name="empty")
+    empty_series = pd.Series(name="empty", dtype='float32')
     out = MinMaxOverlapAggregator(interleave_gaps=True).aggregate(
         empty_series, n_out=1_000
     )

--- a/tests/test_composability.py
+++ b/tests/test_composability.py
@@ -1,0 +1,917 @@
+from email.mime import base
+import pytest
+import numpy as np
+import pandas as pd
+import multiprocessing
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from plotly_resampler import FigureResampler, FigureWidgetResampler, LTTB, EveryNthPoint
+from typing import List
+
+
+# ----------------------- Figure as Base -----------------------
+if True:
+    # -------- All scatters
+    def test_fr_f_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        # 1. All scatters are aggregated
+        fr_f = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_f.data) == 3
+        assert len(fr_f.hf_data) == 3
+        for trace in fr_f.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_f._hf_data
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fr_f = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_f.data) == 3
+        assert len(fr_f.hf_data) == 0
+        for trace in fr_f.data:
+            assert trace.uid not in fr_f._hf_data
+            assert len(trace["y"]) == 10_000
+
+    def test_fwr_f_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Figure
+        # 1. All scatters are aggregated
+        fwr_f = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fwr_f.data) == 3
+        assert len(fwr_f.hf_data) == 3
+        for trace in fwr_f.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_f._hf_data
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fwr_f = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr_f.data) == 3
+        assert len(fwr_f.hf_data) == 0
+        for trace in fwr_f.data:
+            assert trace.uid not in fwr_f._hf_data
+            assert len(trace["y"]) == 10_000
+
+    # ---- Must not be aggregated
+    def test_fr_f_scatter_not_all_agg(float_series, bool_series, cat_series):
+        # TODO hier een variant op met
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series[:1500]), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series[:800]), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        fr_f = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_f.data) == 3
+        assert len(fr_f.hf_data) == 1
+        # Only the fist trace will be aggregated
+        for trace in fr_f.data[:1]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_f._hf_data
+            assert len(trace["y"]) == 2_000
+
+        for trace in fr_f.data[1:]:
+            assert trace.uid not in fr_f._hf_data
+            assert len(trace["y"]) != 2_000
+
+    def test_fwr_f_scatter_not_all_agg(float_series, bool_series, cat_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series[:1500]), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series[:800]), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        fwr_f = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fwr_f.data) == 3
+        assert len(fwr_f.hf_data) == 1
+        # Only the fist trace will be aggregated
+        for trace in fwr_f.data[:1]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_f._hf_data
+            assert len(trace["y"]) == 2_000
+
+        for trace in fwr_f.data[1:]:
+            assert trace.uid not in fwr_f._hf_data
+            assert len(trace["y"]) != 2_000
+
+    # ------- Mixed
+    def test_fr_f_mixed_agg(float_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_f = FigureResampler(base_fig, default_n_shown_samples=1_000)
+        assert len(fr_f.data) == 3
+        assert len(fr_f.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_f.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_f._hf_data
+            assert len(trace["y"]) == 1_000
+
+        for trace in fr_f.data[:1] + fr_f.data[2:]:
+            assert trace.uid not in fr_f._hf_data
+            assert trace.y is None  # these traces don't even have a y value
+
+    def test_fwr_f_mixed_agg(float_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fwr_f = FigureWidgetResampler(base_fig, default_n_shown_samples=1_000)
+        assert len(fwr_f.data) == 3
+        assert len(fwr_f.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fwr_f.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_f._hf_data
+            assert len(trace["y"]) == 1_000
+
+        for trace in fwr_f.data[:1] + fwr_f.data[2:]:
+            assert trace.uid not in fwr_f._hf_data
+            assert trace.y is None  # these traces don't even have a y value
+
+    # ---- Must not (all) be aggregated
+    def test_fr_f_mixed_no_agg(float_series):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_f = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_f.data) == 3
+        assert len(fr_f.hf_data) == 0
+        assert len(fr_f.data[1]["y"]) == 10_000
+
+        fwr_f = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr_f.data) == 3
+        assert len(fwr_f.hf_data) == 0
+        assert len(fwr_f.data[1]["y"]) == 10_000
+
+
+# ----------------------- FigureWidget as Base -----------------------
+if True:
+    # -------- All scatters
+    def test_fr_fw_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        # 1. All scatters are aggregated
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 3
+        for trace in fr_fw.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw._hf_data
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 0
+        for trace in fr_fw.data:
+            assert trace.uid not in fr_fw._hf_data
+            assert len(trace["y"]) == 10_000
+
+    def test_fwr_fw_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Figure
+        # 1. All scatters are aggregated
+        fwr_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fwr_fw.data) == 3
+        assert len(fwr_fw.hf_data) == 3
+        for trace in fwr_fw.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_fw._hf_data
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fwr_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr_fw.data) == 3
+        assert len(fwr_fw.hf_data) == 0
+        for trace in fwr_fw.data:
+            assert trace.uid not in fwr_fw._hf_data
+            assert len(trace["y"]) == 10_000
+
+    # ---- Must not be aggregated
+    def test_fr_fw_scatter_not_all_agg(float_series, bool_series, cat_series):
+        # TODO hier een variant op met
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series[:1500]), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series[:800]), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 1
+        # Only the fist trace will be aggregated
+        for trace in fr_fw.data[:1]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw._hf_data
+            assert len(trace["y"]) == 2_000
+
+        for trace in fr_fw.data[1:]:
+            assert trace.uid not in fr_fw._hf_data
+            assert len(trace["y"]) != 2_000
+
+    def test_fwr_fw_scatter_not_all_agg(float_series, bool_series, cat_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series[:1500]), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series[:800]), row=2, col=1)
+
+        # Create FigureResampler object from a go.Figure
+        fwr_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fwr_fw.data) == 3
+        assert len(fwr_fw.hf_data) == 1
+        # Only the fist trace will be aggregated
+        for trace in fwr_fw.data[:1]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_fw._hf_data
+            assert len(trace["y"]) == 2_000
+
+        for trace in fwr_fw.data[1:]:
+            assert trace.uid not in fwr_fw._hf_data
+            assert len(trace["y"]) != 2_000
+
+    # ------- Mixed
+    def test_fr_fw_mixed_agg(float_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=1_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_fw.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw._hf_data
+            assert len(trace["y"]) == 1_000
+
+        for trace in fr_fw.data[:1] + fr_fw.data[2:]:
+            assert trace.uid not in fr_fw._hf_data
+            assert trace.y is None  # these traces don't even have a y value
+
+    def test_fwr_fw_mixed_agg(float_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fwr_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=1_000)
+        assert len(fwr_fw.data) == 3
+        assert len(fwr_fw.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fwr_fw.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fwr_fw._hf_data
+            assert len(trace["y"]) == 1_000
+
+        for trace in fwr_fw.data[:1] + fwr_fw.data[2:]:
+            assert trace.uid not in fwr_fw._hf_data
+            assert trace.y is None  # these traces don't even have a y value
+
+    # ---- Must not (all) be aggregated
+    def test_fr_fw_mixed_no_agg(float_series):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 0
+        assert len(fr_fw.data[1]["y"]) == 10_000
+
+        fwr_fw = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr_fw.data) == 3
+        assert len(fwr_fw.hf_data) == 0
+        assert len(fwr_fw.data[1]["y"]) == 10_000
+
+
+# ----------------------- FigureResampler As base -----------------------
+if True:
+    # -------- All scatters
+    def test_fr_fr_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = FigureResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fr_fr = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fr.data) == 3
+        assert len(fr_fr.hf_data) == 3
+        for trace in fr_fr.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fr._hf_data
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fr_fr = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_fr.data) == 3
+        assert len(fr_fr.hf_data) == 3
+        for trace in fr_fr.data:
+            assert len(trace["y"]) == 10_000
+
+    def test_fwr_fr_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = FigureResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fw_fr = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fr.data) == 3
+        assert len(fw_fr.hf_data) == 3
+        for trace in fw_fr.data:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fw_fr = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fw_fr.data) == 3
+        # NOTE: the hf_data gets copied so the lenght will be the same length as the
+        # original figure
+        assert len(fw_fr.hf_data) == 3
+        for trace in fw_fr.data:
+            assert len(trace["y"]) == 10_000
+
+    def test_fwr_fr_scatter_agg_no_default(float_series, bool_series, cat_series):
+        base_fig = FigureResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureREsampler object from a FigureResampler
+        # 1. All scatters are aggregated
+        fr_fr = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fr.data) == 3
+        assert len(fr_fr.hf_data) == 3
+        for trace in fr_fr.data[:1] + fr_fr.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fr_fr.data[1]["y"]) == 1000
+
+    def test_fwr_fr_scatter_agg_no_default(float_series, bool_series, cat_series):
+        base_fig = FigureResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fw_fr = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fr.data) == 3
+        assert len(fw_fr.hf_data) == 3
+        for trace in fw_fr.data[:1] + fw_fr.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fw_fr.data[1]["y"]) == 1000
+
+    # -------- Mixed
+    def test_fr_fr_mixed_agg(float_series):
+        base_fig = FigureResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            ),
+            default_n_shown_samples=999,
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fr_mixed = FigureResampler(base_fig, default_n_shown_samples=1_020)
+        assert len(fr_fr_mixed.data) == 3
+        assert len(fr_fr_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_fr_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fr_mixed._hf_data
+            assert len(trace["y"]) == 1_020
+
+        for trace in fr_fr_mixed.data[:1] + fr_fr_mixed.data[2:]:
+            assert trace.uid not in fr_fr_mixed._hf_data
+
+    def test_fr_fr_mixed_no_default_agg(float_series):
+        base_fig = FigureResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2, max_n_samples=1054)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fr_mixed = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fr_mixed.data) == 3
+        assert len(fr_fr_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_fr_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fr_mixed._hf_data
+            assert len(trace["y"]) == 1054
+
+        for trace in fr_fr_mixed.data[:1] + fr_fr_mixed.data[2:]:
+            assert trace.uid not in fr_fr_mixed._hf_data
+
+    def test_fw_fr_mixed_agg(float_series):
+        base_fig = FigureResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            ),
+            default_n_shown_samples=999,
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fw_fr_mixed = FigureWidgetResampler(base_fig, default_n_shown_samples=1_020)
+        assert len(fw_fr_mixed.data) == 3
+        assert len(fw_fr_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fw_fr_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fw_fr_mixed._hf_data
+            assert len(trace["y"]) == 1_020
+
+        for trace in fw_fr_mixed.data[:1] + fw_fr_mixed.data[2:]:
+            assert trace.uid not in fw_fr_mixed._hf_data
+
+    def test_fw_fr_mixed_no_default_agg(float_series):
+        base_fig = FigureResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2, max_n_samples=1054)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fw_fr_mixed = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fr_mixed.data) == 3
+        assert len(fw_fr_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fw_fr_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fw_fr_mixed._hf_data
+            assert len(trace["y"]) == 1054
+
+        for trace in fw_fr_mixed.data[:1] + fw_fr_mixed.data[2:]:
+            assert trace.uid not in fw_fr_mixed._hf_data
+
+
+# ----------------------- FigureWidgetResampler As base -----------------------
+if True:
+    # -------- All scatters
+    def test_fr_fwr_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 3
+        for trace in fr_fw.data:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw._hf_data
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 3
+        for trace in fr_fw.data:
+            assert len(trace["y"]) == 10_000
+
+    def test_fw_fwr_scatter_agg(float_series, bool_series, cat_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fw_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fw.data) == 3
+        assert len(fw_fw.hf_data) == 3
+        for trace in fw_fw.data:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # 2. No scatters are aggregated
+        fw_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fw_fw.data) == 3
+        # NOTE: the hf_data gets copied so the lenght will be the same length as the
+        # original figure
+        assert len(fw_fw.hf_data) == 3
+        for trace in fw_fw.data:
+            assert len(trace["y"]) == 10_000
+
+    def test_fr_fwr_scatter_agg_no_default(float_series, bool_series, cat_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureREsampler object from a FigureResampler
+        # 1. All scatters are aggregated
+        fr_fw = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fw.data) == 3
+        assert len(fr_fw.hf_data) == 3
+        for trace in fr_fw.data[:1] + fr_fw.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fr_fw.data[1]["y"]) == 1000
+
+    def test_fw_fwr_scatter_agg_no_default(float_series, bool_series, cat_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        # Create FigureWidgetResampler object from a go.Scatter
+        # 1. All scatters are aggregated
+        fw_fw = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fw.data) == 3
+        assert len(fw_fw.hf_data) == 3
+        for trace in fw_fw.data[:1] + fw_fw.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fw_fw.data[1]["y"]) == 1000
+
+    # -------- Midex
+    def test_fr_fwr_mixed_agg(float_series):
+        base_fig = FigureWidgetResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            ),
+            default_n_shown_samples=999,
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fw_mixed = FigureResampler(base_fig, default_n_shown_samples=1_020)
+        assert len(fr_fw_mixed.data) == 3
+        assert len(fr_fw_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_fw_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw_mixed._hf_data
+            assert len(trace["y"]) == 1_020
+
+        for trace in fr_fw_mixed.data[:1] + fr_fw_mixed.data[2:]:
+            assert trace.uid not in fr_fw_mixed._hf_data
+
+    def test_fr_fwr_mixed_no_default_agg(float_series):
+        base_fig = FigureWidgetResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2, max_n_samples=1054)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fr_fw_mixed = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fw_mixed.data) == 3
+        assert len(fr_fw_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fr_fw_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fr_fw_mixed._hf_data
+            assert len(trace["y"]) == 1054
+
+        for trace in fr_fw_mixed.data[:1] + fr_fw_mixed.data[2:]:
+            assert trace.uid not in fr_fw_mixed._hf_data
+
+    def test_fw_fwr_mixed_agg(float_series):
+        base_fig = FigureWidgetResampler(
+            go.FigureWidget(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            ),
+            default_n_shown_samples=999,
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fw_fw_mixed = FigureWidgetResampler(base_fig, default_n_shown_samples=1_020)
+        assert len(fw_fw_mixed.data) == 3
+        assert len(fw_fw_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fw_fw_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fw_fw_mixed._hf_data
+            assert len(trace["y"]) == 1_020
+
+        for trace in fw_fw_mixed.data[:1] + fw_fw_mixed.data[2:]:
+            assert trace.uid not in fw_fw_mixed._hf_data
+
+    def test_fw_fwr_mixed_no_default_agg(float_series):
+        base_fig = FigureWidgetResampler(
+            go.Figure(
+                make_subplots(
+                    rows=2,
+                    cols=2,
+                    specs=[[{}, {}], [{"colspan": 2}, None]],
+                )
+            )
+        )
+        base_fig.add_trace(go.Box(x=float_series), row=1, col=1)
+        base_fig.add_trace(dict(y=float_series), row=1, col=2, max_n_samples=1054)
+        base_fig.add_trace(go.Histogram(x=float_series), row=2, col=1)
+
+        fw_fw_mixed = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fw_fw_mixed.data) == 3
+        assert len(fw_fw_mixed.hf_data) == 1  # Only the second trace will be aggregated
+        for trace in fw_fw_mixed.data[1:2]:
+            # ensure that all uids are in the `_hf_data` property
+            assert trace.uid in fw_fw_mixed._hf_data
+            assert len(trace["y"]) == 1054
+
+        for trace in fw_fw_mixed.data[:1] + fw_fw_mixed.data[2:]:
+            assert trace.uid not in fw_fw_mixed._hf_data
+
+
+# =========================================================
+# Performing zoom events on widgets
+if True:
+
+    def test_fr_fwr_scatter_agg(cat_series, bool_series, float_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        base_fig.layout.update(
+            {
+                "xaxis": {"range": [10_000, 20_000]},
+                "yaxis": {"range": [-20, 3]},
+                "xaxis2": {"range": [40_000, 60_000]},
+                "yaxis2": {"range": [-10, 3]},
+            },
+            overwrite=False,
+        )
+
+        fr_fwr = FigureResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fr_fwr.data) == 3
+        assert len(fr_fwr.hf_data) == 3
+        for trace in fr_fwr.data[:1] + fr_fwr.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+            # Verify whether the zoom did not affect antyhign
+            assert trace["x"][0] == 0
+            assert trace["x"][-1] == 9999
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fr_fwr.data[1]["y"]) == 1000
+        assert fr_fwr.data[1]["x"][0] == 0
+        assert fr_fwr.data[1]["x"][-1] == 9999
+
+
+    def test_fwr_fwr_scatter_agg(cat_series, bool_series, float_series):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=1000,
+        )
+        base_fig.add_trace(dict(y=cat_series), row=1, col=1)
+        base_fig.add_trace(go.Scatter(y=bool_series), row=1, col=2, max_n_samples=1000)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        base_fig.layout.update(
+            {
+                "xaxis": {"range": [10_000, 20_000]},
+                "yaxis": {"range": [-20, 3]},
+                "xaxis2": {"range": [40_000, 60_000]},
+                "yaxis2": {"range": [-10, 3]},
+            },
+            overwrite=False,
+        )
+
+        fwr_fwr = FigureWidgetResampler(base_fig, default_n_shown_samples=2_000)
+        assert len(fwr_fwr.data) == 3
+        assert len(fwr_fwr.hf_data) == 3
+        for trace in fwr_fwr.data[:1] + fwr_fwr.data[2:]:
+            # NOTE: default arguments are overtaken, so the default number of samples
+            # of the wrapped `FigureResampler` traces are overriden by the default
+            # number of samples of this class
+            assert len(trace["y"]) == 2_000
+
+            # Verify whether the zoom did not affect antyhign
+            assert trace["x"][0] == 0
+            assert trace["x"][-1] == 9999
+
+        # this was not a default value, so it remains its original value; i.e 1000
+        assert len(fwr_fwr.data[1]["y"]) == 1000
+        assert fwr_fwr.data[1]["x"][0] == 0
+        assert fwr_fwr.data[1]["x"][-1] == 9999

--- a/tests/test_composability.py
+++ b/tests/test_composability.py
@@ -64,7 +64,6 @@ if True:
 
     # ---- Must not be aggregated
     def test_fr_f_scatter_not_all_agg(float_series, bool_series, cat_series):
-        # TODO hier een variant op met
         base_fig = make_subplots(
             rows=2,
             cols=2,
@@ -244,7 +243,6 @@ if True:
 
     # ---- Must not be aggregated
     def test_fr_fw_scatter_not_all_agg(float_series, bool_series, cat_series):
-        # TODO hier een variant op met
         base_fig = go.FigureWidget(
             make_subplots(
                 rows=2,

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -574,7 +574,7 @@ def test_multiple_tz_no_tz_series_slicing():
         t_start = t_start.tz_localize(cs[(i + 1) % len(cs)].index.tz)
         t_stop = t_stop.tz_localize(cs[(i + 2) % len(cs)].index.tz)
 
-        # Now the assumption cannot be made that s ahd the same time-zone as the
+        # Now the assumption cannot be made that s has the same time-zone as the
         # timestamps -> AssertionError will be raised.
         with pytest.raises(AssertionError):
             fig._slice_time(s.tz_localize(None), t_start, t_stop)

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -10,6 +10,7 @@ import multiprocessing
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from plotly_resampler import FigureResampler, LTTB, EveryNthPoint
+from typing import List
 
 
 def test_add_trace_kwarg_space(float_series, bool_series, cat_series):
@@ -573,8 +574,8 @@ def test_multiple_tz_no_tz_series_slicing():
         t_start = t_start.tz_localize(cs[(i + 1) % len(cs)].index.tz)
         t_stop = t_stop.tz_localize(cs[(i + 2) % len(cs)].index.tz)
 
-        # Now the assumpton cannot be made that s ahd the same time-zone as the
-        # timestamps -> Assertionerror will be raised.
+        # Now the assumption cannot be made that s ahd the same time-zone as the
+        # timestamps -> AssertionError will be raised.
         with pytest.raises(AssertionError):
             fig._slice_time(s.tz_localize(None), t_start, t_stop)
 
@@ -661,3 +662,180 @@ def test_fr_from_dict():
     assert len(fr_fig.data[0]["x"]) == 1_000
     assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
     assert (fr_fig.data[0]["y"] == [1] * 1_000).all()
+
+    # assert that all the uuids of data and hf_data match
+    # this is a proxy for assuring that the dynamic aggregation should work
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+
+
+def test_fr_empty_list():
+    # and empty list -> so no concrete traces were added
+    fr_fig = FigureResampler([], default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 0
+    assert len(fr_fig.data) == 0
+
+
+def test_fr_empty_dict():
+    # a dict is a concrete trace so 1 trace should be added
+    fr_fig = FigureResampler({}, default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 0
+    assert len(fr_fig.data) == 1
+
+
+def test_fr_wrong_keys(float_series):
+    base_fig = [
+        {"ydata": float_series.values + 2, "name": "sp2"},
+    ]
+    with pytest.raises(ValueError):
+        FigureResampler(base_fig, default_n_shown_samples=1000)
+
+
+def test_fr_from_list_dict(float_series):
+    base_fig: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+
+    fr_fig = FigureResampler(base_fig, default_n_shown_samples=1000)
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    base_fig.append({"y": float_series[:1000], "name": "s_no_agg"})
+    fr_fig = FigureResampler(base_fig, default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+
+def test_fr_list_dict_add_traces(float_series):
+    fr_fig = FigureResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+    fr_fig.add_traces(traces)
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    fr_fig.add_traces({"y": float_series[:1000], "name": "s_no_agg"})
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    fr_fig.add_traces([{"y": float_series[:100], "name": "s_agg"}], limit_to_views=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    # note that we use a tuple as input here
+    fr_fig.add_traces(({"y": float_series[:1000], "name": "s_agg"},), max_n_samples=999)
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5
+
+
+def test_fr_list_dict_add_trace(float_series):
+    fr_fig = FigureResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+    for trace in traces:
+        fr_fig.add_trace(trace)
+
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    fr_fig.add_trace({"y": float_series[:1000], "name": "s_no_agg"})
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    fr_fig.add_trace({"y": float_series[:100], "name": "s_agg"}, limit_to_view=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    lf_series = {"y": float_series[:1000], "name": "s_agg"}
+    # plotly its default behavior raises a ValueError when a list or tuple is passed
+    # to add_trace
+    with pytest.raises(ValueError):
+        fr_fig.add_trace([lf_series], max_n_samples=999)
+    with pytest.raises(ValueError):
+        fr_fig.add_trace((lf_series,), max_n_samples=999)
+
+    fr_fig.add_trace(lf_series, max_n_samples=999)
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5
+
+
+def test_fr_list_scatter_add_traces(float_series):
+    fr_fig = FigureResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        go.Scattergl({"y": float_series.values + 2, "name": "sp2"}),
+        go.Scatter({"y": float_series.values, "name": "s"}),
+    ]
+    fr_fig.add_traces(tuple(traces))
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    fr_fig.add_traces([go.Scattergl({"y": float_series[:1000], "name": "s_no_agg"})])
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    fr_fig.add_traces(go.Scattergl(), limit_to_views=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    fr_fig.add_traces(
+        go.Scatter({"y": float_series[:1000], "name": "s_agg"}), max_n_samples=999
+    )
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -5,6 +5,7 @@ __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
 from copy import copy
 from datetime import datetime
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -577,8 +578,8 @@ def test_multiple_tz_no_tz_series_slicing():
         t_start = t_start.tz_localize(cs[(i + 1) % len(cs)].index.tz)
         t_stop = t_stop.tz_localize(cs[(i + 2) % len(cs)].index.tz)
 
-        # Now the assumpton cannot be made that s ahd the same time-zone as the
-        # timestamps -> Assertionerror will be raised.
+        # Now the assumption cannot be made that s ahd the same time-zone as the
+        # timestamps -> AssertionError will be raised.
         with pytest.raises(AssertionError):
             fig._slice_time(s.tz_localize(None), t_start, t_stop)
 
@@ -1052,7 +1053,7 @@ def test_bare_update_methods():
         == 0
     )
 
-    # Perform an autorange udpate -> assert that the range i
+    # Perform an autorange update -> assert that the range i
     fw_fig._relayout_hist.clear()
     fw_fig.layout.update({"xaxis2": {"autorange": True}, "yaxis2": {"autorange": True}})
     assert len(fw_fig._relayout_hist) == 0
@@ -1095,7 +1096,7 @@ def test_fwr_add_empty_trace():
     assert len(fig.hf_data[0]["y"]) == 0
 
 
-def test_fwr_updata_trace_data_zoom():
+def test_fwr_update_trace_data_zoom():
     k = 50_000
     fig = FigureWidgetResampler(
         go.FigureWidget(make_subplots(rows=2, cols=1)), verbose=True
@@ -1334,7 +1335,7 @@ def test_fwr_adjust_series_input():
     x = fig.data[0]["x"]
     y = fig.data[0]["y"]
 
-    # asser that hf x and y its values are used and not its index
+    # assert that hf x and y its values are used and not its index
     assert x[0] == -2000
     assert y[0] >= 5
 
@@ -1365,7 +1366,7 @@ def test_fwr_adjust_series_text_input():
     x = fig.data[0]["x"]
     y = fig.data[0]["y"]
 
-    # asser that hf x and y its values are used and not its index
+    # assert that hf x and y its values are used and not its index
     assert x[0] == -2000
     assert y[0] >= 10
 
@@ -1547,3 +1548,179 @@ def test_fwr_from_dict():
     assert len(fr_fig.data[0]["x"]) == 1_000
     assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
     assert (fr_fig.data[0]["y"] == [1] * 1_000).all()
+
+    # assert that all the uuids of data and hf_data match
+    # this is a proxy for assuring that the dynamic aggregation should work
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+
+
+def test_fwr_empty_list():
+    # and empty list -> so no concrete traces were added
+    fr_fig = FigureWidgetResampler([], default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 0
+    assert len(fr_fig.data) == 0
+
+
+def test_fwr_empty_dict():
+    # a dict is a concrete trace so 1 trace should be added
+    fr_fig = FigureWidgetResampler({}, default_n_shown_samples=1000)
+    assert len(fr_fig._hf_data) == 0
+    assert len(fr_fig.data) == 1
+
+
+def test_fwr_wrong_keys(float_series):
+    base_fig = [
+        {"ydata": float_series.values + 2, "name": "sp2"},
+    ]
+    with pytest.raises(ValueError):
+        FigureWidgetResampler(base_fig, default_n_shown_samples=1000)
+
+
+def test_fwr_from_list_dict(float_series):
+    base_fig: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+
+    fr_fig = FigureWidgetResampler(base_fig, default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    base_fig.append({'y': float_series[:1000], 'name': "s_no_agg"})
+    fr_fig = FigureWidgetResampler(base_fig, default_n_shown_samples=1000)
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+
+def test_fwr_list_dict_add_trace(float_series):
+    fr_fig = FigureWidgetResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+    for trace in traces:
+        fr_fig.add_trace(trace)
+
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    fr_fig.add_trace({'y': float_series[:1000], 'name': "s_no_agg"})
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    fr_fig.add_trace({'y': float_series[:100], 'name': "s_agg"}, limit_to_view=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    lf_series = {'y': float_series[:1000], 'name': "s_agg"}
+    # plotly its default behavior raises a ValueError when a list or tuple is passed
+    # to add_trace
+    with pytest.raises(ValueError):
+        fr_fig.add_trace([lf_series], max_n_samples=999)
+    with pytest.raises(ValueError):
+        fr_fig.add_trace((lf_series,), max_n_samples=999)
+
+    fr_fig.add_trace(lf_series, max_n_samples=999)
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5
+
+
+def test_fwr_list_dict_add_traces(float_series):
+    fr_fig = FigureWidgetResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        {"y": float_series.values + 2, "name": "sp2"},
+        {"y": float_series.values, "name": "s"},
+    ]
+    fr_fig.add_traces(traces)
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    # plotly also allows a dict or a scatter object as input
+    fr_fig.add_traces({'y': float_series[:1000], 'name': "s_no_agg"})
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    fr_fig.add_traces([{'y': float_series[:100], 'name': "s_agg"}], limit_to_views=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    # note that we use tuple as input
+    fr_fig.add_traces(({'y': float_series[:1000], 'name': "s_agg"}, ), max_n_samples=999)
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5
+
+
+def test_fwr_list_scatter_add_traces(float_series):
+    fr_fig = FigureWidgetResampler(default_n_shown_samples=1000)
+
+    traces: List[dict] = [
+        go.Scattergl({"y": float_series.values + 2, "name": "sp2"}),
+        go.Scatter({"y": float_series.values, "name": "s"}),
+    ]
+    fr_fig.add_traces(tuple(traces))
+    # both traces are HF traces so should be aggregated
+    assert len(fr_fig.hf_data) == 2
+    assert (fr_fig.hf_data[0]["y"] == float_series + 2).all()
+    assert (fr_fig.hf_data[1]["y"] == float_series).all()
+    assert len(fr_fig.data) == 2
+    assert len(fr_fig.data[0]["x"]) == 1_000
+    assert (fr_fig.data[0]["x"][0] >= 0) & (fr_fig.data[0]["x"][-1] < 10_000)
+    assert (fr_fig.data[1]["x"][0] >= 0) & (fr_fig.data[1]["x"][-1] < 10_000)
+
+    # assert that all the uuids of data and hf_data match
+    assert fr_fig.data[0].uid in fr_fig._hf_data
+    assert fr_fig.data[1].uid in fr_fig._hf_data
+
+    # redo the exercise with a new low-freq trace
+    fr_fig.add_traces([go.Scattergl({'y': float_series[:1000], 'name': "s_no_agg"})])
+    assert len(fr_fig.hf_data) == 2
+    assert len(fr_fig.data) == 3
+
+    # add low-freq trace but set limit_to_view to True
+    # note how the scatter object is not encapsulated within a list
+    fr_fig.add_traces(go.Scattergl(), limit_to_views=True)
+    assert len(fr_fig.hf_data) == 3
+    assert len(fr_fig.data) == 4
+
+    # add a low-freq trace but adjust max_n_samples
+    fr_fig.add_traces(go.Scatter({'y': float_series[:1000], 'name': "s_agg"}), max_n_samples=999)
+    assert len(fr_fig.hf_data) == 4
+    assert len(fr_fig.data) == 5

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -578,7 +578,7 @@ def test_multiple_tz_no_tz_series_slicing():
         t_start = t_start.tz_localize(cs[(i + 1) % len(cs)].index.tz)
         t_stop = t_stop.tz_localize(cs[(i + 2) % len(cs)].index.tz)
 
-        # Now the assumption cannot be made that s ahd the same time-zone as the
+        # Now the assumption cannot be made that s has the same time-zone as the
         # timestamps -> AssertionError will be raised.
         with pytest.raises(AssertionError):
             fig._slice_time(s.tz_localize(None), t_start, t_stop)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,8 @@ import plotly.graph_objects as go
 from plotly_resampler.figure_resampler.utils import (
     is_figure,
     is_figurewidget,
+    is_fr,
+    is_fwr,
     timedelta_to_str,
     round_td_str,
     round_number_str,
@@ -24,6 +26,20 @@ def test_is_figure():
     assert not is_figure(FigureWidgetResampler(fig_dict))
 
 
+def test_is_fr():
+    fig_dict = {"type": "scatter", "y": [1, 2, 3]}
+    assert is_fr(FigureResampler())
+    assert is_fr(FigureResampler(fig_dict))
+    assert not is_fr(go.Figure())
+    assert not is_fr(go.Figure(fig_dict))
+    assert not is_fr(go.FigureWidget())
+    assert not is_fr(None)
+    assert not is_fr(fig_dict)
+    assert not is_fr(go.Scatter(y=[1, 2, 3]))
+    assert not is_fr(FigureWidgetResampler())
+    assert not is_fr(FigureWidgetResampler(fig_dict))
+
+
 def test_is_figurewidget():
     fig_dict = {"type": "scatter", "y": [1, 2, 3]}
     assert is_figurewidget(go.FigureWidget())
@@ -36,6 +52,20 @@ def test_is_figurewidget():
     assert not is_figurewidget(go.Scatter(y=[1, 2, 3]))
     assert not is_figurewidget(FigureResampler())
     assert not is_figurewidget(FigureResampler(fig_dict))
+
+
+def test_is_fwr():
+    fig_dict = {"type": "scatter", "y": [1, 2, 3]}
+    assert is_fwr(FigureWidgetResampler())
+    assert is_fwr(FigureWidgetResampler(fig_dict))
+    assert not is_fwr(go.FigureWidget())
+    assert not is_fwr(go.FigureWidget(fig_dict))
+    assert not is_fwr(go.Figure())
+    assert not is_fwr(None)
+    assert not is_fwr(fig_dict)
+    assert not is_fwr(go.Scatter(y=[1, 2, 3]))
+    assert not is_fwr(FigureResampler())
+    assert not is_fwr(FigureResampler(fig_dict))
 
 
 def test_timedelta_to_str():


### PR DESCRIPTION
To cope with better integration of other libraries we think that composing figures should be possible. 

relevant #70, #68

i.e. having a `FigureWidget` as input to a`FigureResampler or wrapping a `FigureResampler` with a `FigureWidgetResampler`
This PR. contains the code-base to tackle this issue. 

**main compose takeaway**:  Each composer will output the visualization at its full scale (i.e., if a zoomed in figurewidget(resampler) is composed, that composed object will show the (aggregated) unzoomed data)

notebook to replicate functionality and aid with tests: [register_pr.zip](https://github.com/predict-idlab/plotly-resampler/files/8884757/register_pr.zip)

TODO:
- [ ] verify docs
  - [x] input types of constructors
- [ ] rewrite docs
- [x] Write tests
   - [x] Test composability of a non hf-trace, but where we set limit_to_view to True (this functionality should work)

I would rewrite the docs on the `register_pr` branch, as this is tightly coupled with that one