### PR TITLE
Mimic Dash error if running app on port already in use

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -164,7 +164,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
 
         # check if self._port is already in use
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if s.connect_ex(('localhost', int(self._port))) == 0:
+            if s.connect_ex((self._host, int(self._port))) == 0:
                 error_message = "Address already in use\n" \
                     f"Port {self._port} is in use by another program. " \
                     "Either identify and stop that program, or start the server with a different port."

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -168,8 +168,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
                 error_message = "Address already in use\n" \
                     f"Port {self._port} is in use by another program. " \
                     "Either identify and stop that program, or start the server with a different port."
-                print(error_message)
-                sys.exit(1)
+                raise socket.error(error_message)
 
         app.run_server(mode=mode, **kwargs)
 

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
+import sys
+import socket
 import warnings
 from typing import Tuple
 
@@ -159,6 +161,15 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         self._app = app
         self._host = kwargs.get("host", "127.0.0.1")
         self._port = kwargs.get("port", "8050")
+
+        # check if self._port is already in use
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(('localhost', int(self._port))) == 0:
+                error_message = "Address already in use\n" \
+                    f"Port {self._port} is in use by another program. " \
+                    "Either identify and stop that program, or start the server with a different port."
+                print(error_message)
+                sys.exit(1)
 
         app.run_server(mode=mode, **kwargs)
 


### PR DESCRIPTION
closes #73.

In Dash if you try to do this you get an output like:
```
Address already in use
Port 8080 is in use by another program. Either identify and stop that program, or start the server with a different port.
```

So we mimic that here.