### PR TITLE
✨ adding `convert_traces_kwargs`

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -39,6 +39,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             "",
         ),
         show_mean_aggregation_size: bool = True,
+        convert_traces_kwargs: dict | None = None,
         verbose: bool = False,
     ):
         # Parse the figure input before calling `super`
@@ -67,6 +68,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             default_downsampler,
             resampled_trace_prefix_suffix,
             show_mean_aggregation_size,
+            convert_traces_kwargs,
             verbose,
         )
 

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -48,6 +48,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             "",
         ),
         show_mean_aggregation_size: bool = True,
+        convert_traces_kwargs: dict | None = None,
         verbose: bool = False,
     ):
         """Instantiate a resampling data mirror.
@@ -82,6 +83,12 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         show_mean_aggregation_size: bool, optional
             Whether the mean aggregation bin size will be added as a suffix to the trace
             its legend-name, by default True.
+        convert_traces_kwargs: dict, optional
+            A dict of kwargs that will be passed to the :func:`add_traces` method and
+            will be used to convert the existing traces. \n
+            .. note::
+                This argument is only used when the passed ``figure`` contains data and
+                ``convert_existing_traces`` is set to True.
         verbose: bool, optional
             Whether some verbose messages will be printed or not, by default False.
 
@@ -109,9 +116,12 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             f_._grid_ref = figure._grid_ref
             super().__init__(f_)
 
+            if convert_traces_kwargs is None:
+                convert_traces_kwargs = {}
+
             # make sure that the UIDs of these traces do not get adjusted
             self._data_validator.set_uid = False
-            self.add_traces(figure.data)
+            self.add_traces(figure.data, **convert_traces_kwargs)
         else:
             super().__init__(figure)
             self._data_validator.set_uid = False
@@ -432,7 +442,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         .. Note::
             This method will always return a plotly constructor, even when the given
-            `constr` is decorated (after executing the ``register_plotly_resampler`` 
+            `constr` is decorated (after executing the ``register_plotly_resampler``
             function).
 
         Parameters
@@ -952,7 +962,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         .. note::
             Make sure to look at the :func:`add_trace` function for more info about
-            **speed optimization**, and dealing with not ``high-frequency`` data, but 
+            **speed optimization**, and dealing with not ``high-frequency`` data, but
             still want to resample / limit the data to the front-end view.
 
         Parameters

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -49,6 +49,7 @@ class FigureWidgetResampler(
             "",
         ),
         show_mean_aggregation_size: bool = True,
+        convert_traces_kwargs: dict | None = None,
         verbose: bool = False,
     ):
         # Parse the figure input before calling `super`
@@ -71,6 +72,7 @@ class FigureWidgetResampler(
             default_downsampler,
             resampled_trace_prefix_suffix,
             show_mean_aggregation_size,
+            convert_traces_kwargs,
             verbose,
         )
 

--- a/tests/test_composability.py
+++ b/tests/test_composability.py
@@ -1,3 +1,4 @@
+from random import sample
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from plotly_resampler import FigureResampler, FigureWidgetResampler
@@ -33,6 +34,60 @@ if True:
         for trace in fr_f.data:
             assert trace.uid not in fr_f._hf_data
             assert len(trace["y"]) == 10_000
+
+    def test_fr_fwr_f_scatter_convert_traces_kwargs(
+        float_series, bool_series, cat_series
+    ):
+        base_fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{}, {}], [{"colspan": 2}, None]],
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        fwr = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr.hf_data) == 0
+
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fwr.hf_data) == 3
+
+        n_sample_list = [1010, 1020, 1030]
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fwr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fwr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
+
+        # FigureResampler as wrapped class
+        fr = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr.hf_data) == 0
+
+        fr = FigureResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fr.hf_data) == 3
+
+        fr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
 
     def test_fwr_f_scatter_agg(float_series, bool_series, cat_series):
         base_fig = make_subplots(
@@ -210,6 +265,62 @@ if True:
         for trace in fr_fw.data:
             assert trace.uid not in fr_fw._hf_data
             assert len(trace["y"]) == 10_000
+
+    def test_fr_fwr_fw_scatter_convert_traces_kwargs(
+        float_series, bool_series, cat_series
+    ):
+        base_fig = go.FigureWidget(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            )
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        fwr = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr.hf_data) == 0
+
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fwr.hf_data) == 3
+
+        n_sample_list = [1010, 1020, 1030]
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fwr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fwr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
+
+        # FigureResampler as wrapped class
+        fr = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr.hf_data) == 0
+
+        fr = FigureResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fr.hf_data) == 3
+
+        fr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
 
     def test_fwr_fw_scatter_agg(float_series, bool_series, cat_series):
         base_fig = go.FigureWidget(
@@ -402,6 +513,63 @@ if True:
         assert len(fr_fr.hf_data) == 3
         for trace in fr_fr.data:
             assert len(trace["y"]) == 10_000
+
+    def test_fr_fwr_fr_scatter_convert_traces_kwargs(
+        float_series, bool_series, cat_series
+    ):
+        base_fig = FigureResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=10_000,
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        fwr = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr.hf_data) == 0
+
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fwr.hf_data) == 3
+
+        n_sample_list = [1010, 1020, 1030]
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fwr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fwr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
+
+        # FigureResampler as wrapped class
+        fr = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr.hf_data) == 0
+
+        fr = FigureResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fr.hf_data) == 3
+
+        fr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
 
     def test_fr_fr_scatter_no_agg_agg(float_series, bool_series, cat_series):
         # This initial figure object does not contain any aggregated data as
@@ -779,6 +947,63 @@ if True:
         assert len(fr_fw.hf_data) == 3
         for trace in fr_fw.data:
             assert len(trace["y"]) == 10_000
+
+    def test_fr_fwr_fwr_scatter_convert_traces_kwargs(
+        float_series, bool_series, cat_series
+    ):
+        base_fig = FigureWidgetResampler(
+            make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {}], [{"colspan": 2}, None]],
+            ),
+            default_n_shown_samples=10_000,
+        )
+        base_fig.add_trace(go.Scatter(y=cat_series), row=1, col=1)
+        base_fig.add_trace(dict(y=bool_series), row=1, col=2)
+        base_fig.add_trace(go.Scattergl(y=float_series), row=2, col=1)
+
+        fwr = FigureWidgetResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fwr.hf_data) == 0
+
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fwr.hf_data) == 3
+
+        n_sample_list = [1010, 1020, 1030]
+        fwr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fwr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fwr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
+
+        # FigureResampler as wrapped class
+        fr = FigureResampler(base_fig, default_n_shown_samples=10_000)
+        assert len(fr.hf_data) == 0
+
+        fr = FigureResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(limit_to_views=True),
+        )
+        assert len(fr.hf_data) == 3
+
+        fr = FigureWidgetResampler(
+            base_fig,
+            default_n_shown_samples=10_000,
+            convert_traces_kwargs=dict(max_n_samples=n_sample_list),
+        )
+        assert len(fr.hf_data) == 3
+        for i, n_samples in enumerate(n_sample_list):
+            assert len(fr.data[i]["y"]) == n_samples
+            assert len(fwr.hf_data[i]["y"]) == 10_000
 
     def test_fr_fwr_scatter_no_agg_agg(float_series, bool_series, cat_series):
         # This inital figure object does not contain any aggregated data as


### PR DESCRIPTION
Allows to use all the arguments of the `add_traces` function; e.g. `limit_to_views`, `max_n_samples`, ...