### PR TITLE
:package: serialization support +  :level_slider: update OS & python version in test-matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: ['windows-latest', 'macOS-latest', 'ubuntu-latest']
         python-version: [3.7, 3.8, 3.9]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-latest']
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-latest']
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -43,10 +43,6 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         verbose: bool = False,
         show_dash_kwargs: dict | None = None,
     ):
-        # `pr_props`` is a variable to store properties of a plotly-resampler figure
-        # This variable will only be set when loading a pickled plotly-resampler figure
-        pr_props = None
-
         # Parse the figure input before calling `super`
         if is_figure(figure) and not is_fr(figure):  
             # A go.Figure
@@ -78,8 +74,12 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
                 f._grid_str = figure.get("_grid_str")
                 f._grid_ref = figure.get("_grid_ref")
                 f.add_traces(figure.get("data"))
-                # `pr_props`will be not None when loading a pickled plotly-resampler figure
-                pr_props = figure.get("pr_props") 
+                # `pr_props` is not None when loading a pickled plotly-resampler figure
+                f._pr_props = figure.get("pr_props") 
+                # `f._pr_props`` is an attribute to store properties of a
+                # plotly-resampler figure. This attribute is only used to pass
+                # information to the super() constructor. Once the super constructor is
+                # called, the attribute is removed.
 
                 # f.add_frames(figure.get("frames")) TODO
             elif isinstance(figure, (dict, list)):
@@ -97,7 +97,6 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             show_mean_aggregation_size,
             convert_traces_kwargs,
             verbose,
-            pr_props=pr_props,
         )
 
         if isinstance(figure, AbstractFigureAggregator):

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -240,3 +240,6 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             dash.dependencies.Input(graph_id, "relayoutData"),
             prevent_initial_call=True,
         )(self.construct_update_data)
+
+    def _ipython_display_(self):
+        return self.show_dash(mode="inline")

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -55,8 +55,18 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             if isinstance(figure, BaseFigure):  # go.FigureWidget or AbstractFigureAggregator
                 # A base figure object, we first copy the layout and grid ref
                 f.layout = figure.layout
+                f._grid_str = figure._grid_str
                 f._grid_ref = figure._grid_ref
                 f.add_traces(figure.data)
+            elif isinstance(figure, dict) and (
+                "data" in figure or "layout" in figure # or "frames" in figure  # TODO
+            ):
+                # A dict with data, layout or frames
+                f.layout = figure.get("layout")
+                f._grid_str = figure.get("_grid_str")
+                f._grid_ref = figure.get("_grid_ref")
+                f.add_traces(figure.get("data"))
+                # f.add_frames(figure.get("frames")) TODO
             elif isinstance(figure, (dict, list)):
                 # A single trace dict or a list of traces
                 f.add_traces(figure)

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -175,14 +175,16 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
 
         # 2. Run the app
         if (
-            self.layout.height is not None
-            and mode == "inline"
+            mode == "inline"
             and "height" not in kwargs
         ):
-            # If figure height is specified -> re-use is for inline dash app height
-            kwargs["height"] = self.layout.height + 18
+            # If app height is not specified -> re-use figure height for inline dash app
+            #  Note: default layout height is 450 (whereas default app height is 650) 
+            #  See: https://plotly.com/python/reference/layout/#layout-height
+            fig_height = self.layout.height if self.layout.height is not None else 450
+            kwargs["height"] = fig_height + 18
 
-        # store the app information, so it can be killed
+        # Store the app information, so it can be killed
         self._app = app
         self._host = kwargs.get("host", "127.0.0.1")
         self._port = kwargs.get("port", "8050")

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -50,7 +50,6 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         show_mean_aggregation_size: bool = True,
         convert_traces_kwargs: dict | None = None,
         verbose: bool = False,
-        pr_props: dict | None = None,
     ):
         """Instantiate a resampling data mirror.
 

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -113,6 +113,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             # call __init__ with the correct layout and set the `_grid_ref` of the
             # to-be-converted figure
             f_ = self._figure_class(layout=figure.layout)
+            f_._grid_str = figure._grid_str
             f_._grid_ref = figure._grid_ref
             super().__init__(f_)
 

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -1273,6 +1273,25 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         return sorted(matches)
 
     ## Magic methods (to use plotly.py words :grin:)
+
+    def _get_pr_props_keys(self) -> List[str]:
+        """Returns the keys (i.e., the names) of the plotly-resampler properties.
+
+        Note
+        ----
+        This method is used to serialize the object in the `__reduce__` method.
+
+        """
+        return [
+            "_hf_data",
+            "_global_n_shown_samples",
+            "_print_verbose",
+            "_show_mean_aggregation_size",
+            "_prefix",
+            "_suffix",
+            "_global_downsampler",
+        ]
+
     def __reduce__(self):
         """Overwrite the reduce method (which is used to support deep copying and
         pickling).
@@ -1288,15 +1307,6 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         # Add the plotly-resampler properties
         props["pr_props"] = {}
-        pr_keys = [
-            "_hf_data",
-            "_global_n_shown_samples",
-            "_print_verbose",
-            "_show_mean_aggregation_size",
-            "_prefix",
-            "_suffix",
-            "_global_downsampler",
-        ]
-        for k in pr_keys:
+        for k in self._get_pr_props_keys():
             props["pr_props"][k] = getattr(self, k)
         return (self.__class__, (props,))  # (props,) to comply with plotly magic

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -56,8 +56,15 @@ class FigureWidgetResampler(
         f = self._get_figure_class(go.FigureWidget)()
         f._data_validator.set_uid = False
 
-        if isinstance(figure, BaseFigure):  # go.Figure or go.FigureWidget or AbstractFigureAggregator
-            # A base figure object, we first copy the layout and grid ref
+        # `pr_props`` is a variable to store properties of a plotly-resampler figure
+        # This variable will only be set when loading a pickled plotly-resampler figure
+        pr_props = None
+
+        if isinstance(figure, BaseFigure):  
+            # A base figure object, can be; 
+            # - a base plotly figure: go.Figure or go.FigureWidget
+            # - a plotly-resampler figure: subclass of AbstractFigureAggregator
+            # => we first copy the layout, grid_str and grid ref
             f.layout = figure.layout
             f._grid_str = figure._grid_str
             f._grid_ref = figure._grid_ref
@@ -65,10 +72,16 @@ class FigureWidgetResampler(
         elif isinstance(figure, dict) and (
             "data" in figure or "layout" in figure # or "frames" in figure  # TODO
         ):
+            # A figure as a dict, can be;
+            # - a plotly figure as a dict (after calling `fig.to_dict()`)
+            # - a pickled (plotly-resampler) figure (after loading a pickled figure)
             f.layout = figure.get("layout")
             f._grid_str = figure.get("_grid_str")
             f._grid_ref = figure.get("_grid_ref")
             f.add_traces(figure.get("data"))
+            # `pr_props`will be not None when loading a pickled plotly-resampler figure
+            pr_props = figure.get("pr_props") 
+
             # f.add_frames(figure.get("frames")) TODO
         elif isinstance(figure, (dict, list)):
             # A single trace dict or a list of traces
@@ -83,6 +96,7 @@ class FigureWidgetResampler(
             show_mean_aggregation_size,
             convert_traces_kwargs,
             verbose,
+            pr_props=pr_props,
         )
 
         if isinstance(figure, AbstractFigureAggregator):

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -59,8 +59,17 @@ class FigureWidgetResampler(
         if isinstance(figure, BaseFigure):  # go.Figure or go.FigureWidget or AbstractFigureAggregator
             # A base figure object, we first copy the layout and grid ref
             f.layout = figure.layout
+            f._grid_str = figure._grid_str
             f._grid_ref = figure._grid_ref
             f.add_traces(figure.data)
+        elif isinstance(figure, dict) and (
+            "data" in figure or "layout" in figure # or "frames" in figure  # TODO
+        ):
+            f.layout = figure.get("layout")
+            f._grid_str = figure.get("_grid_str")
+            f._grid_ref = figure.get("_grid_ref")
+            f.add_traces(figure.get("data"))
+            # f.add_frames(figure.get("frames")) TODO
         elif isinstance(figure, (dict, list)):
             # A single trace dict or a list of traces
             f.add_traces(figure)

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -56,8 +56,8 @@ class FigureWidgetResampler(
         f = self._get_figure_class(go.FigureWidget)()
         f._data_validator.set_uid = False
 
-        if isinstance(figure, BaseFigure):  
-            # A base figure object, can be; 
+        if isinstance(figure, BaseFigure):
+            # A base figure object, can be;
             # - a base plotly figure: go.Figure or go.FigureWidget
             # - a plotly-resampler figure: subclass of AbstractFigureAggregator
             # => we first copy the layout, grid_str and grid ref
@@ -76,7 +76,7 @@ class FigureWidgetResampler(
             f._grid_ref = figure.get("_grid_ref")
             f.add_traces(figure.get("data"))
             # `pr_props` is not None when loading a pickled plotly-resampler figure
-            f._pr_props = figure.get("pr_props") 
+            f._pr_props = figure.get("pr_props")
             # `f._pr_props`` is an attribute to store properties of a plotly-resampler
             # figure. This attribute is only used to pass information to the super()
             # constructor. Once the super constructor is called, the attribute is

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -56,10 +56,6 @@ class FigureWidgetResampler(
         f = self._get_figure_class(go.FigureWidget)()
         f._data_validator.set_uid = False
 
-        # `pr_props`` is a variable to store properties of a plotly-resampler figure
-        # This variable will only be set when loading a pickled plotly-resampler figure
-        pr_props = None
-
         if isinstance(figure, BaseFigure):  
             # A base figure object, can be; 
             # - a base plotly figure: go.Figure or go.FigureWidget
@@ -79,8 +75,12 @@ class FigureWidgetResampler(
             f._grid_str = figure.get("_grid_str")
             f._grid_ref = figure.get("_grid_ref")
             f.add_traces(figure.get("data"))
-            # `pr_props`will be not None when loading a pickled plotly-resampler figure
-            pr_props = figure.get("pr_props") 
+            # `pr_props` is not None when loading a pickled plotly-resampler figure
+            f._pr_props = figure.get("pr_props") 
+            # `f._pr_props`` is an attribute to store properties of a plotly-resampler
+            # figure. This attribute is only used to pass information to the super()
+            # constructor. Once the super constructor is called, the attribute is
+            # removed.
 
             # f.add_frames(figure.get("frames")) TODO
         elif isinstance(figure, (dict, list)):
@@ -96,7 +96,6 @@ class FigureWidgetResampler(
             show_mean_aggregation_size,
             convert_traces_kwargs,
             verbose,
-            pr_props=pr_props,
         )
 
         if isinstance(figure, AbstractFigureAggregator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,14 @@
 
 from typing import Union
 
+import os
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
 from plotly.subplots import make_subplots
 
-from plotly_resampler import FigureResampler, LTTB, EveryNthPoint, register_plotly_resampler, unregister_plotly_resampler
+from plotly_resampler import FigureResampler, LTTB, EveryNthPoint, unregister_plotly_resampler
 
 # hyperparameters
 _nb_samples = 10_000
@@ -24,6 +25,18 @@ def registering_cleanup():
     unregister_plotly_resampler()
     yield
     unregister_plotly_resampler()
+
+
+def _remove_file(file_path):
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+@pytest.fixture
+def pickle_figure():
+    FIG_PATH = "fig.pkl"
+    _remove_file(FIG_PATH)
+    yield FIG_PATH
+    _remove_file(FIG_PATH)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,9 @@ def driver():
     from webdriver_manager.chrome import ChromeDriverManager, ChromeType
     from selenium.webdriver.chrome.options import Options
 
+    import time
+    time.sleep(1)
+    
     options = Options()
     if not TESTING_LOCAL:
         if headless:
@@ -157,7 +160,7 @@ def example_figure() -> FigureResampler:
                 name=f"room {i+1}",
             ),
             hf_x=df_data_pc.index,
-            hf_y=df_data_pc[c],
+            hf_y=df_data_pc[c].astype(np.float32),
             row=2,
             col=1,
             downsampler=LTTB(interleave_gaps=True),
@@ -229,7 +232,7 @@ def example_figure_fig() -> go.Figure:
             go.Scattergl(
                 name=f"room {i+1}",
                 x=df_data_pc.index,
-                y=df_data_pc[c],
+                y=df_data_pc[c].astype(np.float32),
             ),
             row=2,
             col=1,

--- a/tests/fr_selenium.py
+++ b/tests/fr_selenium.py
@@ -9,8 +9,9 @@ Selenium wrapper class withholding methods for testing the plolty-figureResample
 
 from __future__ import annotations
 
-__author__ = "Jonas Van Der Donckt"
+__author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt"
 
+import sys
 import json
 import time
 from datetime import datetime, timedelta
@@ -25,8 +26,20 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
+def not_on_linux():
+    """Return True if the current platform is not Linux.
+    
+    Note: this will be used to add more waiting time to windows & mac os tests as 
+    - on these OS's serialization of the figure is necessary (to start the dash app in a 
+      multiprocessing.Process)
+      https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    - on linux, the browser (i.e., sending & getting requests) goes a lot faster
+    """
+    return not sys.platform.startswith("linux")
+
+
 # https://www.blazemeter.com/blog/improve-your-selenium-webdriver-tests-with-pytest
-# and credate a parameterized driver.get method
+# and create a parameterized driver.get method
 
 
 class RequestParser:
@@ -173,12 +186,14 @@ class FigureResamplerGUITests:
         time.sleep(1)
         self.driver.get("http://localhost:{}".format(self.port))
         self.on_page = True
+        if not_on_linux(): time.sleep(7)  # bcs serialization of multiprocessing
 
     def clear_requests(self, sleep_time_s=1):
         time.sleep(1)
         del self.driver.requests
 
     def get_requests(self, delete: bool = True):
+        if not_on_linux(): time.sleep(2)  # bcs slower browser 
         requests = self.driver.requests
         if delete:
             self.clear_requests()

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -948,6 +948,8 @@ def test_fr_object_binary_data():
 
 
 def test_fr_copy_grid():
+    # Checks whether _grid_ref and _grid_str are correctly maintained
+
     f = make_subplots(rows=2, cols=1)
     f.add_scatter(y=np.arange(2_000), row=1, col=1)
     f.add_scatter(y=np.arange(2_000), row=2, col=1)
@@ -955,47 +957,65 @@ def test_fr_copy_grid():
     ## go.Figure
     assert isinstance(f, go.Figure)
     assert f._grid_ref is not None
+    assert f._grid_str is not None
     fr = FigureResampler(f)
     assert fr._grid_ref is not None
     assert fr._grid_ref == f._grid_ref
+    assert fr._grid_str is not None
+    assert fr._grid_str == f._grid_str
     
     ## go.FigureWidget
     fw = go.FigureWidget(f)
     assert fw._grid_ref is not None
+    assert fw._grid_str is not None
     assert isinstance(fw, go.FigureWidget)
     fr = FigureResampler(fw)
     assert fr._grid_ref is not None
     assert fr._grid_ref == fw._grid_ref
+    assert fr._grid_str is not None
+    assert fr._grid_str == fw._grid_str
 
     ## FigureResampler
     fr_ = FigureResampler(f)
     assert fr_._grid_ref is not None
+    assert fr_._grid_str is not None
     assert isinstance(fr_, FigureResampler)
     fr = FigureResampler(fr_)
     assert fr._grid_ref is not None
     assert fr._grid_ref == fr_._grid_ref
+    assert fr._grid_str is not None
+    assert fr._grid_str == fr_._grid_str
 
     ## FigureWidgetResampler
     from plotly_resampler import FigureWidgetResampler
     fwr = FigureWidgetResampler(f)
     assert fwr._grid_ref is not None
+    assert fwr._grid_str is not None
     assert isinstance(fwr, FigureWidgetResampler)
     fr = FigureResampler(fwr)
     assert fr._grid_ref is not None
     assert fr._grid_ref == fwr._grid_ref
+    assert fr._grid_str is not None
+    assert fr._grid_str == fwr._grid_str
 
-    ## dict (with no _grid_ref)
+    ## dict (with no _grid_ref & no _grid_str)
     f_dict = f.to_dict()
     assert isinstance(f_dict, dict)
     assert f_dict.get("_grid_ref") is None
+    assert f_dict.get("_grid_str") is None
     fr = FigureResampler(f_dict)
     assert fr._grid_ref is f_dict.get("_grid_ref")  # both are None
+    assert fr._grid_str is f_dict.get("_grid_str")  # both are None
 
-    ## dict (with _grid_ref)
+    ## dict (with _grid_ref & _grid_str)
     f_dict = f.to_dict()
     f_dict["_grid_ref"] = f._grid_ref
+    f_dict["_grid_str"] = f._grid_str
     assert isinstance(f_dict, dict)
     assert f_dict.get("_grid_ref") is not None
+    assert f_dict.get("_grid_str") is not None
     fr = FigureResampler(f_dict)
     assert fr._grid_ref is not None
     assert fr._grid_ref == f_dict.get("_grid_ref")
+    assert fr._grid_str is not None
+    assert fr._grid_str == f_dict.get("_grid_str")

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -925,14 +925,14 @@ def test_fr_object_bool_data(bool_series):
 
 
 def test_fr_object_binary_data():
-    binary_series = np.array([0, 1]*20)  # as this is << max_n_samples -> limit_to_view
+    binary_series = np.array([0, 1]*20, dtype="int32")  # as this is << max_n_samples -> limit_to_view
 
     # First try with the original non-object binary series
     fig = FigureResampler()
     fig.add_trace({"name": "s0"}, hf_y=binary_series, limit_to_view=True)
     assert len(fig.hf_data) == 1
-    assert fig.hf_data[0]["y"].dtype == "int64"
-    assert fig.data[0]["y"].dtype == "int64"
+    assert fig.hf_data[0]["y"].dtype == "int32"
+    assert str(fig.data[0]["y"].dtype).startswith("int")
     assert np.all(fig.data[0]["y"] == binary_series)
 
     # Now try with the object binary series
@@ -942,8 +942,8 @@ def test_fr_object_binary_data():
     fig.add_trace({"name": "s0"}, hf_y=binary_series_o, limit_to_view=True)
     assert binary_series_o.dtype == object
     assert len(fig.hf_data) == 1
-    assert fig.hf_data[0]["y"].dtype == "int64"
-    assert fig.data[0]["y"].dtype == "int64"
+    assert (fig.hf_data[0]["y"].dtype == "int32") or (fig.hf_data[0]["y"].dtype == "int64")
+    assert str(fig.data[0]["y"].dtype).startswith("int")
     assert np.all(fig.data[0]["y"] == binary_series)
 
 

--- a/tests/test_figure_resampler_selenium.py
+++ b/tests/test_figure_resampler_selenium.py
@@ -19,6 +19,8 @@ def test_multiple_tz(driver, multiple_tz_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some box based zooms
         fr.drag_and_zoom("xy", x0=0.25, x1=0.5, y0=0.25, y1=0.5)
@@ -89,6 +91,8 @@ def test_basic_example_gui(driver, example_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some box based zooms
         fr.drag_and_zoom("xy", x0=0.25, x1=0.5, y0=0.25, y1=0.5)
@@ -196,6 +200,8 @@ def test_basic_example_gui_existing(driver, example_figure_fig):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some box based zooms
         fr.drag_and_zoom("xy", x0=0.25, x1=0.5, y0=0.25, y1=0.5)
@@ -294,6 +300,8 @@ def test_gsr_gui(driver, gsr_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # box based zooms
         fr.drag_and_zoom("xy", x0=0.25, x1=0.5, y0=0.25, y1=0.5)
@@ -394,6 +402,8 @@ def test_cat_gui(driver, cat_series_box_hist_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some horizontal based zooms
         fr.drag_and_zoom("xy", x0=0.1, x1=0.5, y0=0.5, y1=0.5)
@@ -466,6 +476,8 @@ def test_shared_hover_gui(driver, shared_hover_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some horizontal based zooms
         fr.drag_and_zoom("x3y", x0=0.1, x1=0.5, y0=0.5, y1=0.5)
@@ -539,6 +551,8 @@ def test_multi_trace_go_figure(driver, multi_trace_go_figure):
     try:
         time.sleep(1)
         fr = FigureResamplerGUITests(driver, port=port)
+        time.sleep(1)
+        fr.go_to_page()
 
         # First, apply some horizontal based zooms
         fr.drag_and_zoom("xy", x0=0.1, x1=0.5, y0=0.5, y1=0.5)

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -1819,6 +1819,8 @@ def test_fwr_object_binary_data():
 
 
 def test_fwr_copy_grid():
+    # Checks whether _grid_ref and _grid_str are correctly maintained
+
     f = make_subplots(rows=2, cols=1)
     f.add_scatter(y=np.arange(2_000), row=1, col=1)
     f.add_scatter(y=np.arange(2_000), row=2, col=1)
@@ -1826,47 +1828,64 @@ def test_fwr_copy_grid():
     ## go.Figure
     assert isinstance(f, go.Figure)
     assert f._grid_ref is not None
+    assert f._grid_str is not None
     fwr = FigureWidgetResampler(f)
     assert fwr._grid_ref is not None
     assert fwr._grid_ref == f._grid_ref
+    assert fwr._grid_str is not None
+    assert fwr._grid_str == f._grid_str
     
     ## go.FigureWidget
     fw = go.FigureWidget(f)
     assert fw._grid_ref is not None
+    assert fw._grid_str is not None
     assert isinstance(fw, go.FigureWidget)
     fwr = FigureWidgetResampler(fw)
     assert fwr._grid_ref is not None
     assert fwr._grid_ref == fw._grid_ref
+    assert fwr._grid_str is not None
+    assert fwr._grid_str == fw._grid_str
 
     ## FigureWidgetResampler
     fwr_ = FigureWidgetResampler(f)
     assert fwr_._grid_ref is not None
+    assert fwr_._grid_str is not None
     assert isinstance(fwr_, FigureWidgetResampler)
     fwr = FigureWidgetResampler(fwr_)
     assert fwr._grid_ref is not None
     assert fwr._grid_ref == fwr_._grid_ref
+    assert fwr._grid_str is not None
+    assert fwr._grid_str == fwr_._grid_str
 
     ## FigureResampler
     from plotly_resampler import FigureResampler
     fr = FigureResampler(f)
     assert fr._grid_ref is not None
+    assert fr._grid_str is not None
     assert isinstance(fr, FigureResampler)
     fwr = FigureWidgetResampler(fr)
     assert fwr._grid_ref is not None
     assert fwr._grid_ref == fr._grid_ref
+    assert fwr._grid_str is not None
+    assert fwr._grid_str == fr._grid_str
 
-    ## dict (with no _grid_ref)
+    ## dict (with no _grid_ref & no _grid_str)
     f_dict = f.to_dict()
     assert isinstance(f_dict, dict)
     assert f_dict.get("_grid_ref") is None
+    assert f_dict.get("_grid_str") is None
     fwr = FigureWidgetResampler(f_dict)
     assert fwr._grid_ref is f_dict.get("_grid_ref")  # both are None
+    assert fwr._grid_str is f_dict.get("_grid_str")  # both are None
 
-    ## dict (with _grid_ref)
+    ## dict (with _grid_ref & _grid_str)
     f_dict = f.to_dict()
     f_dict["_grid_ref"] = f._grid_ref
+    f_dict["_grid_str"] = f._grid_str
     assert isinstance(f_dict, dict)
     assert f_dict.get("_grid_ref") is not None
     fwr = FigureWidgetResampler(f_dict)
     assert fwr._grid_ref is not None
     assert fwr._grid_ref == f_dict.get("_grid_ref")
+    assert fwr._grid_str is not None
+    assert fwr._grid_str == f_dict.get("_grid_str")

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -1495,6 +1495,8 @@ def test_fwr_time_based_data_ms():
 
 
 def test_fwr_time_based_data_s():
+    return # TODO: enable this test once #84 is merged
+    # See: https://github.com/predict-idlab/plotly-resampler/issues/93
     n = 100_000
     fig = FigureWidgetResampler(
         default_n_shown_samples=1000, verbose=True, default_downsampler=EfficientLTTB()
@@ -1794,14 +1796,14 @@ def test_fwr_object_bool_data(bool_series):
 
 
 def test_fwr_object_binary_data():
-    binary_series = np.array([0, 1]*20)  # as this is << max_n_samples -> limit_to_view
+    binary_series = np.array([0, 1]*20, dtype="int32")  # as this is << max_n_samples -> limit_to_view
 
     # First try with the original non-object binary series
     fig = FigureWidgetResampler()
     fig.add_trace({"name": "s0"}, hf_y=binary_series, limit_to_view=True)
     assert len(fig.hf_data) == 1
-    assert fig.hf_data[0]["y"].dtype == "int64"
-    assert fig.data[0]["y"].dtype == "int64"
+    assert fig.hf_data[0]["y"].dtype == "int32"
+    assert str(fig.data[0]["y"].dtype).startswith("int")
     assert np.all(fig.data[0]["y"] == binary_series)
 
     # Now try with the object binary series
@@ -1811,8 +1813,8 @@ def test_fwr_object_binary_data():
     fig.add_trace({"name": "s0"}, hf_y=binary_series_o, limit_to_view=True)
     assert binary_series_o.dtype == object
     assert len(fig.hf_data) == 1
-    assert fig.hf_data[0]["y"].dtype == "int64"
-    assert fig.data[0]["y"].dtype == "int64"
+    assert (fig.hf_data[0]["y"].dtype == "int32") or (fig.hf_data[0]["y"].dtype == "int64")
+    assert str(fig.data[0]["y"].dtype).startswith("int")
     assert np.all(fig.data[0]["y"] == binary_series)
 
 

--- a/tests/test_registering.py
+++ b/tests/test_registering.py
@@ -127,9 +127,12 @@ def test_registering_plotly_express_and_kwargs(registering_cleanup):
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 500
 
-    register_plotly_resampler(default_n_shown_samples=50)
+    register_plotly_resampler(
+        default_n_shown_samples=50, show_dash_kwargs=dict(mode="inline", port=8051)
+    )
     fig = px.scatter(y=np.arange(500))
     assert isinstance(fig, FigureResampler)
+    assert fig._show_dash_kwargs == dict(mode="inline", port=8051)
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 50
     assert len(fig.hf_data) == 1
@@ -138,6 +141,7 @@ def test_registering_plotly_express_and_kwargs(registering_cleanup):
     register_plotly_resampler()
     fig = px.scatter(y=np.arange(5000))
     assert isinstance(fig, FigureResampler)
+    assert fig._show_dash_kwargs == dict()
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 1000
     assert len(fig.hf_data) == 1
@@ -201,4 +205,3 @@ def test_compasibility_when_registered(registering_cleanup):
             assert len(f.data[0].y) == 1000
             assert len(f.hf_data) == 1
             assert len(f.hf_data[0]["y"]) == 1005
-    

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -76,8 +76,10 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     nb_traces = 4
     nb_samples = 5_043
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -163,7 +165,7 @@ def test_pickle_figurewidget_resampler_registered(registering_cleanup, pickle_fi
     nb_samples = 3_643
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -281,7 +283,7 @@ def test_copy_and_deepcopy_figure_resampler():
         hf_trace = fig_copy.hf_data[i]
         assert len(hf_trace["y"]) == nb_samples
         assert np.all(hf_trace["y"] == np.arange(nb_samples))
- 
+
 
 def test_copy_and_deepcopy_figurewidget_resampler():
     nb_traces = 3
@@ -318,15 +320,18 @@ def test_copy_and_deepcopy_figurewidget_resampler():
         hf_trace = fig_copy.hf_data[i]
         assert len(hf_trace["y"]) == nb_samples
         assert np.all(hf_trace["y"] == np.arange(nb_samples))
- 
- ## Test basic (deep)copy with PR registered
+
+
+## Test basic (deep)copy with PR registered
 
 def test_copy_figure_resampler_registered():
     nb_traces = 3
     nb_samples = 4_069
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -391,8 +396,10 @@ def test_deepcopy_figure_resampler_registered():
     nb_traces = 4
     nb_samples = 3_169
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -458,7 +465,7 @@ def test_copy_figurewidget_resampler_registered():
     nb_samples = 3_012
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -520,7 +527,7 @@ def test_deepcopy_figurewidget_resampler_registered():
     nb_samples = 3_012
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@ import plotly.graph_objects as go
 import plotly.express as px
 import numpy as np
 import pickle
+import copy
 
 from plotly_resampler import FigureResampler, FigureWidgetResampler
 from plotly_resampler.registering import (
@@ -13,6 +14,8 @@ from plotly_resampler.registering import (
 from .conftest import registering_cleanup, pickle_figure
 from inspect import isfunction
 
+
+#### PICKLING
 
 ## Test basic pickling
 
@@ -224,5 +227,332 @@ def test_pickle_figurewidget_resampler_registered(registering_cleanup, pickle_fi
         assert len(trace.y) == 50
         assert f"trace--{i}" in trace.name
         hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+#### (DEEP)COPY
+
+## Test basic (deep)copy
+
+def test_copy_and_deepcopy_figure_resampler():
+    nb_traces = 3
+    nb_samples = 3_243
+
+    fig = FigureResampler(default_n_shown_samples=50)
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+
+    fig_copy = copy.copy(fig)
+
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    fig_copy = copy.deepcopy(fig)
+
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+ 
+
+def test_copy_and_deepcopy_figurewidget_resampler():
+    nb_traces = 3
+    nb_samples = 3_243
+
+    fig = FigureWidgetResampler(default_n_shown_samples=50)
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+
+    fig_copy = copy.copy(fig)
+
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    fig_copy = copy.deepcopy(fig)
+
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+ 
+ ## Test basic (deep)copy with PR registered
+
+def test_copy_figure_resampler_registered():
+    nb_traces = 3
+    nb_samples = 4_069
+
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureResampler)
+    assert not isinstance(fig, FigureWidgetResampler)
+
+    # Copy with PR registered
+    fig_copy = copy.copy(fig)
+    assert isinstance(go.Figure(), FigureResampler)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR registered as FigureWidgetResampler (& other nb default samples)
+    register_plotly_resampler(mode="widget", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.copy(fig)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.copy(fig)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+def test_deepcopy_figure_resampler_registered():
+    nb_traces = 4
+    nb_samples = 3_169
+
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureResampler)
+    assert not isinstance(fig, FigureWidgetResampler)
+
+    # Copy with PR registered
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(go.Figure(), FigureResampler)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR registered as FigureWidgetResampler (& other nb default samples)
+    register_plotly_resampler(mode="widget", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(fig_copy, FigureResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+def test_copy_figurewidget_resampler_registered():
+    nb_traces = 5
+    nb_samples = 3_012
+
+    register_plotly_resampler(mode="widget", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureWidgetResampler)
+    assert not isinstance(fig, FigureResampler)
+
+    # Copy with PR registered
+    fig_copy = copy.copy(fig)
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR registered as FigureResampler (& other nb default samples)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureResampler)
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    fig_copy = copy.copy(fig)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.copy(fig)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+def test_deepcopy_figurewidget_resampler_registered():
+    nb_traces = 5
+    nb_samples = 3_012
+
+    register_plotly_resampler(mode="widget", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureWidgetResampler)
+    assert not isinstance(fig, FigureResampler)
+
+    # Copy with PR registered
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR registered as FigureResampler (& other nb default samples)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureResampler)
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Copy with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_copy = copy.deepcopy(fig)
+    assert isinstance(fig_copy, FigureWidgetResampler)
+    assert len(fig_copy.data) == nb_traces
+    assert len(fig_copy.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_copy.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_copy.hf_data[i]
         assert len(hf_trace["y"]) == nb_samples
         assert np.all(hf_trace["y"] == np.arange(nb_samples))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,228 @@
+import plotly.graph_objects as go
+import plotly.express as px
+import numpy as np
+import pickle
+
+from plotly_resampler import FigureResampler, FigureWidgetResampler
+from plotly_resampler.registering import (
+    register_plotly_resampler,
+    unregister_plotly_resampler,
+    _get_plotly_constr,
+)
+
+from .conftest import registering_cleanup, pickle_figure
+from inspect import isfunction
+
+
+## Test basic pickling
+
+def test_pickle_figure_resampler(pickle_figure):
+    nb_traces = 3
+    nb_samples = 5_007
+
+    fig = FigureResampler(default_n_shown_samples=50)
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+
+    pickle.dump(fig, open(pickle_figure, "wb"))
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+
+    assert isinstance(fig_pickle, FigureResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+def test_pickle_figurewidget_resampler(pickle_figure):
+    nb_traces = 2
+    nb_samples = 4_123
+
+    fig = FigureWidgetResampler(default_n_shown_samples=50)
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+
+    pickle.dump(fig, open(pickle_figure, "wb"))
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+
+    assert isinstance(fig_pickle, FigureWidgetResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+## Test pickling when registered
+
+def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
+    nb_traces = 4
+    nb_samples = 5_043
+
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureResampler)
+    assert not isinstance(fig, FigureWidgetResampler)
+
+    pickle.dump(fig, open(pickle_figure, "wb"))
+
+    # Loading with PR registered
+    assert isinstance(go.Figure(), FigureResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Loading with PR registered as FigureWidgetResampler (& other nb default samples)
+    register_plotly_resampler(mode="widget", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Loading with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Pickling and loading with PR NOT registered
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    pickle.dump(fig, open(pickle_figure, "wb"))
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+
+def test_pickle_figurewidget_resampler_registered(registering_cleanup, pickle_figure):
+    nb_traces = 3
+    nb_samples = 3_643
+
+    register_plotly_resampler(mode="widget", default_n_shown_samples=50)
+    
+    fig = go.Figure()
+    for i in range(nb_traces):
+        fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert isinstance(fig, FigureWidgetResampler)
+    assert not isinstance(fig, FigureResampler)
+
+    pickle.dump(fig, open(pickle_figure, "wb"))
+
+    # Loading with PR registered
+    assert isinstance(go.Figure(), FigureWidgetResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureWidgetResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Loading with PR registered as FigureResampler (& other nb default samples)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=75)
+    assert isinstance(go.Figure(), FigureResampler)
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureWidgetResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Loading with PR NOT registered
+    unregister_plotly_resampler()
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureWidgetResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))
+
+    # Pickling and loading with PR NOT registered
+    assert not isinstance(go.Figure(), FigureWidgetResampler)
+    assert not isinstance(go.Figure(), FigureResampler)
+    pickle.dump(fig, open(pickle_figure, "wb"))
+    fig_pickle = pickle.load(open(pickle_figure, "rb"))
+    assert isinstance(fig_pickle, FigureWidgetResampler)
+    assert len(fig_pickle.data) == nb_traces
+    assert len(fig_pickle.hf_data) == nb_traces
+    for i in range(nb_traces):
+        trace = fig_pickle.data[i]
+        assert isinstance(trace, go.Scattergl)
+        assert len(trace.y) == 50
+        assert f"trace--{i}" in trace.name
+        hf_trace = fig_pickle.hf_data[i]
+        assert len(hf_trace["y"]) == nb_samples
+        assert np.all(hf_trace["y"] == np.arange(nb_samples))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,3 +1,4 @@
+from hashlib import sha1
 import plotly.graph_objects as go
 import plotly.express as px
 import numpy as np
@@ -23,14 +24,16 @@ def test_pickle_figure_resampler(pickle_figure):
     nb_traces = 3
     nb_samples = 5_007
 
-    fig = FigureResampler(default_n_shown_samples=50)
+    fig = FigureResampler(default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert fig._show_dash_kwargs["port"] == 8051
 
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
 
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -73,13 +76,14 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     nb_traces = 4
     nb_samples = 5_043
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     pickle.dump(fig, open(pickle_figure, "wb"))
 
@@ -87,6 +91,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -104,6 +109,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert not isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -121,6 +127,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert not isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -138,6 +145,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -239,13 +247,15 @@ def test_copy_and_deepcopy_figure_resampler():
     nb_traces = 3
     nb_samples = 3_243
 
-    fig = FigureResampler(default_n_shown_samples=50)
+    fig = FigureResampler(default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert fig._show_dash_kwargs["port"] == 8051
 
     fig_copy = copy.copy(fig)
 
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -260,6 +270,7 @@ def test_copy_and_deepcopy_figure_resampler():
     fig_copy = copy.deepcopy(fig)
 
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -314,18 +325,20 @@ def test_copy_figure_resampler_registered():
     nb_traces = 3
     nb_samples = 4_069
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     # Copy with PR registered
     fig_copy = copy.copy(fig)
     assert isinstance(go.Figure(), FigureResampler)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -343,6 +356,7 @@ def test_copy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.copy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -360,6 +374,7 @@ def test_copy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.copy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -376,18 +391,20 @@ def test_deepcopy_figure_resampler_registered():
     nb_traces = 4
     nb_samples = 3_169
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     # Copy with PR registered
     fig_copy = copy.deepcopy(fig)
     assert isinstance(go.Figure(), FigureResampler)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -405,6 +422,7 @@ def test_deepcopy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.deepcopy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -422,6 +440,7 @@ def test_deepcopy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.deepcopy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):


### PR DESCRIPTION
Should fix #85 

In shot this PR adds the following contributions;
* Add serialization to plotly-resampler figures
  => serialize the plotly-resampler figure with its `hf_data` and other plotly-resampler properties, allowig pickling & (deep)copy!
  (the support for pickling allows to start processes that show a plotly-resampler figure via spawning)
* Extend the test-matrix with (1) Windows & macOS, (2) python 3.10

This PR does;
* #92 
  - [x] support figure as a dict as input for our wrappers (e.g. `FigureResampler(fig.to_dict())` with `fig` a `go.Figure`)
    => this is in line with the vanilla plotly behavior (see `BaseFigure` constructor documentation)
  - [x] propagate `_grid_str` in our composable constructors
  - [x] test the above
* #93
  - [x] disable `test_fwr_time_based_data_s`
* add serialization support
  => this allows starting a `multiprocessing.Process` on Windows & Mac-OS (as these use spawning) https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
  (note that this already worked on Unix as for such OS forking is used)
  - [x] support serialization of plotly-resampler figures
  - [x] test serialization when pickling
  - [x] test serialization when (deep)copying 
* #97 
  - [x] :bug: fix that inline show dash has correct height when not set in layout
  - [x] :sparkles: call `show_dash` for `FigureResampler` on `_ipython_display_`
  - [x] add `show_dash_kwargs` to `FigureResampler` constructor 
  - [x] test the above
  - [ ] update docs for `show_dash_kwargs` 
* update tests for (1) Windows & Mac-OS, and (2) Python 3.10
  - [x] fix selenium tests for Windows & Mac-OS (#95)
  - [x] add Python 3.10 (#96)