### PR TITLE
:fire: add support for figure dict input + propagate _grid_str

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -55,8 +55,18 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             if isinstance(figure, BaseFigure):  # go.FigureWidget or AbstractFigureAggregator
                 # A base figure object, we first copy the layout and grid ref
                 f.layout = figure.layout
+                f._grid_str = figure._grid_str
                 f._grid_ref = figure._grid_ref
                 f.add_traces(figure.data)
+            elif isinstance(figure, dict) and (
+                "data" in figure or "layout" in figure # or "frames" in figure  # TODO
+            ):
+                # A dict with data, layout or frames
+                f.layout = figure.get("layout")
+                f._grid_str = figure.get("_grid_str")
+                f._grid_ref = figure.get("_grid_ref")
+                f.add_traces(figure.get("data"))
+                # f.add_frames(figure.get("frames")) TODO
             elif isinstance(figure, (dict, list)):
                 # A single trace dict or a list of traces
                 f.add_traces(figure)

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -113,6 +113,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             # call __init__ with the correct layout and set the `_grid_ref` of the
             # to-be-converted figure
             f_ = self._figure_class(layout=figure.layout)
+            f_._grid_str = figure._grid_str
             f_._grid_ref = figure._grid_ref
             super().__init__(f_)
 

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -59,8 +59,17 @@ class FigureWidgetResampler(
         if isinstance(figure, BaseFigure):  # go.Figure or go.FigureWidget or AbstractFigureAggregator
             # A base figure object, we first copy the layout and grid ref
             f.layout = figure.layout
+            f._grid_str = figure._grid_str
             f._grid_ref = figure._grid_ref
             f.add_traces(figure.data)
+        elif isinstance(figure, dict) and (
+            "data" in figure or "layout" in figure # or "frames" in figure  # TODO
+        ):
+            f.layout = figure.get("layout")
+            f._grid_str = figure.get("_grid_str")
+            f._grid_ref = figure.get("_grid_ref")
+            f.add_traces(figure.get("data"))
+            # f.add_frames(figure.get("frames")) TODO
         elif isinstance(figure, (dict, list)):
             # A single trace dict or a list of traces
             f.add_traces(figure)


### PR DESCRIPTION
This PR does;
- [x] support figure as a dict as input for our wrappers (e.g. `FigureResampler(fig.to_dict())` with `fig` a `go.Figure`)
  => this is in line with the vanilla plotly behavior (see `BaseFigure` constructor documentation)
- [x] propagate `_grid_str` in our composable constructors
- [x] test the above