### PR TITLE
:sunrise: FigureResampler display improvements

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -240,3 +240,6 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             dash.dependencies.Input(graph_id, "relayoutData"),
             prevent_initial_call=True,
         )(self.construct_update_data)
+
+    def _ipython_display_(self):
+        return self.show_dash(mode="inline")

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -175,14 +175,16 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
 
         # 2. Run the app
         if (
-            self.layout.height is not None
-            and mode == "inline"
+            mode == "inline"
             and "height" not in kwargs
         ):
-            # If figure height is specified -> re-use is for inline dash app height
-            kwargs["height"] = self.layout.height + 18
+            # If app height is not specified -> re-use figure height for inline dash app
+            #  Note: default layout height is 450 (whereas default app height is 650) 
+            #  See: https://plotly.com/python/reference/layout/#layout-height
+            fig_height = self.layout.height if self.layout.height is not None else 450
+            kwargs["height"] = fig_height + 18
 
-        # store the app information, so it can be killed
+        # Store the app information, so it can be killed
         self._app = app
         self._host = kwargs.get("host", "127.0.0.1")
         self._port = kwargs.get("port", "8050")

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -1273,6 +1273,25 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         return sorted(matches)
 
     ## Magic methods (to use plotly.py words :grin:)
+
+    def _get_pr_props_keys(self) -> List[str]:
+        """Returns the keys (i.e., the names) of the plotly-resampler properties.
+
+        Note
+        ----
+        This method is used to serialize the object in the `__reduce__` method.
+
+        """
+        return [
+            "_hf_data",
+            "_global_n_shown_samples",
+            "_print_verbose",
+            "_show_mean_aggregation_size",
+            "_prefix",
+            "_suffix",
+            "_global_downsampler",
+        ]
+
     def __reduce__(self):
         """Overwrite the reduce method (which is used to support deep copying and
         pickling).
@@ -1288,15 +1307,6 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         # Add the plotly-resampler properties
         props["pr_props"] = {}
-        pr_keys = [
-            "_hf_data",
-            "_global_n_shown_samples",
-            "_print_verbose",
-            "_show_mean_aggregation_size",
-            "_prefix",
-            "_suffix",
-            "_global_downsampler",
-        ]
-        for k in pr_keys:
+        for k in self._get_pr_props_keys():
             props["pr_props"][k] = getattr(self, k)
         return (self.__class__, (props,))  # (props,) to comply with plotly magic

--- a/tests/test_registering.py
+++ b/tests/test_registering.py
@@ -127,9 +127,12 @@ def test_registering_plotly_express_and_kwargs(registering_cleanup):
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 500
 
-    register_plotly_resampler(default_n_shown_samples=50)
+    register_plotly_resampler(
+        default_n_shown_samples=50, show_dash_kwargs=dict(mode="inline", port=8051)
+    )
     fig = px.scatter(y=np.arange(500))
     assert isinstance(fig, FigureResampler)
+    assert fig._show_dash_kwargs == dict(mode="inline", port=8051)
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 50
     assert len(fig.hf_data) == 1
@@ -138,6 +141,7 @@ def test_registering_plotly_express_and_kwargs(registering_cleanup):
     register_plotly_resampler()
     fig = px.scatter(y=np.arange(5000))
     assert isinstance(fig, FigureResampler)
+    assert fig._show_dash_kwargs == dict()
     assert len(fig.data) == 1
     assert len(fig.data[0].y) == 1000
     assert len(fig.hf_data) == 1
@@ -201,4 +205,3 @@ def test_compasibility_when_registered(registering_cleanup):
             assert len(f.data[0].y) == 1000
             assert len(f.hf_data) == 1
             assert len(f.hf_data[0]["y"]) == 1005
-    

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -76,8 +76,10 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     nb_traces = 4
     nb_samples = 5_043
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -163,7 +165,7 @@ def test_pickle_figurewidget_resampler_registered(registering_cleanup, pickle_fi
     nb_samples = 3_643
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -281,7 +283,7 @@ def test_copy_and_deepcopy_figure_resampler():
         hf_trace = fig_copy.hf_data[i]
         assert len(hf_trace["y"]) == nb_samples
         assert np.all(hf_trace["y"] == np.arange(nb_samples))
- 
+
 
 def test_copy_and_deepcopy_figurewidget_resampler():
     nb_traces = 3
@@ -318,15 +320,18 @@ def test_copy_and_deepcopy_figurewidget_resampler():
         hf_trace = fig_copy.hf_data[i]
         assert len(hf_trace["y"]) == nb_samples
         assert np.all(hf_trace["y"] == np.arange(nb_samples))
- 
- ## Test basic (deep)copy with PR registered
+
+
+## Test basic (deep)copy with PR registered
 
 def test_copy_figure_resampler_registered():
     nb_traces = 3
     nb_samples = 4_069
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -391,8 +396,10 @@ def test_deepcopy_figure_resampler_registered():
     nb_traces = 4
     nb_samples = 3_169
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
-    
+    register_plotly_resampler(
+        mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051)
+    )
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -458,7 +465,7 @@ def test_copy_figurewidget_resampler_registered():
     nb_samples = 3_012
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
@@ -520,7 +527,7 @@ def test_deepcopy_figurewidget_resampler_registered():
     nb_samples = 3_012
 
     register_plotly_resampler(mode="widget", default_n_shown_samples=50)
-    
+
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,3 +1,4 @@
+from hashlib import sha1
 import plotly.graph_objects as go
 import plotly.express as px
 import numpy as np
@@ -23,14 +24,16 @@ def test_pickle_figure_resampler(pickle_figure):
     nb_traces = 3
     nb_samples = 5_007
 
-    fig = FigureResampler(default_n_shown_samples=50)
+    fig = FigureResampler(default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert fig._show_dash_kwargs["port"] == 8051
 
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
 
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -73,13 +76,14 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     nb_traces = 4
     nb_samples = 5_043
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     pickle.dump(fig, open(pickle_figure, "wb"))
 
@@ -87,6 +91,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -104,6 +109,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert not isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -121,6 +127,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     assert not isinstance(go.Figure(), FigureResampler)
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -138,6 +145,7 @@ def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
     assert isinstance(fig_pickle, FigureResampler)
+    assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -239,13 +247,15 @@ def test_copy_and_deepcopy_figure_resampler():
     nb_traces = 3
     nb_samples = 3_243
 
-    fig = FigureResampler(default_n_shown_samples=50)
+    fig = FigureResampler(default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
+    assert fig._show_dash_kwargs["port"] == 8051
 
     fig_copy = copy.copy(fig)
 
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -260,6 +270,7 @@ def test_copy_and_deepcopy_figure_resampler():
     fig_copy = copy.deepcopy(fig)
 
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -314,18 +325,20 @@ def test_copy_figure_resampler_registered():
     nb_traces = 3
     nb_samples = 4_069
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     # Copy with PR registered
     fig_copy = copy.copy(fig)
     assert isinstance(go.Figure(), FigureResampler)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -343,6 +356,7 @@ def test_copy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.copy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -360,6 +374,7 @@ def test_copy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.copy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -376,18 +391,20 @@ def test_deepcopy_figure_resampler_registered():
     nb_traces = 4
     nb_samples = 3_169
 
-    register_plotly_resampler(mode="figure", default_n_shown_samples=50)
+    register_plotly_resampler(mode="figure", default_n_shown_samples=50, show_dash_kwargs=dict(port=8051))
     
     fig = go.Figure()
     for i in range(nb_traces):
         fig.add_trace(go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples))
     assert isinstance(fig, FigureResampler)
     assert not isinstance(fig, FigureWidgetResampler)
+    assert fig._show_dash_kwargs["port"] == 8051
 
     # Copy with PR registered
     fig_copy = copy.deepcopy(fig)
     assert isinstance(go.Figure(), FigureResampler)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -405,6 +422,7 @@ def test_deepcopy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.deepcopy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -422,6 +440,7 @@ def test_deepcopy_figure_resampler_registered():
     assert not isinstance(go.Figure(), FigureResampler)
     fig_copy = copy.deepcopy(fig)
     assert isinstance(fig_copy, FigureResampler)
+    assert fig_copy._show_dash_kwargs["port"] == 8051
     assert len(fig_copy.data) == nb_traces
     assert len(fig_copy.hf_data) == nb_traces
     for i in range(nb_traces):


### PR DESCRIPTION
This PR does;
- [x] remove the empty space under inline `FigureResampler` when height is not passed
(*this is because [the default plotly figure height is 450](https://plotly.com/python/reference/layout/#layout-height), but [the default jupyter-dash app height is 650](https://github.com/plotly/jupyter-dash/blob/86e5746615b78c84ba4c31f6ccf8ea0da3174373/jupyter_dash/jupyter_app.py#L460-L464)* :point_right: :point_left: )
- [x] add `show_dash_kwargs` to `FigureResampler` 
- [x] test the above
- [x] when `ipython display` is called on a  `FigureResampler` it will start an inline jupyter-dash app
- [x] extend tests to also check for other properties that are not in `_get_pr_props_keys`

This PR adds the following behavior to `FigureResampler`; when having `fig` as output in your notebook (`_ipython_display_`) -> now a dash app will be started under the hood with `mode = "inline"`

Users can control the port and other properties of the dash app via the `show_dash_kwargs` that is added to the constructor of `FigureResampler`. This can be set in two manners;
- `fig = FigureResampler(..., show_dash_kwargs=dict(port=8051))`
- `register_plotly_resampler(mode="figure", show_dash_kwargs=dict(port=8051))`