### PR TITLE
:sparkles: add check_nans to add_trace(s)

### DIFF
--- a/plotly_resampler/registering.py
+++ b/plotly_resampler/registering.py
@@ -33,7 +33,7 @@ def _get_plotly_constr(constr):
     Parameters
     ----------
     constr : callable
-        The constructor of a instantiatedplotly-object.
+        The constructor of a instantiated plotly-object.
 
     Returns
     -------
@@ -98,10 +98,10 @@ def register_plotly_resampler(mode="auto", **aggregator_kwargs):
         The mode of the plotly-resampler.
         Possible values are: 'auto', 'figure', 'widget', None.
         If 'auto' is used, the mode is determined based on the environment; if it is in
-        an ipython environment, the mode is 'widget', otherwise it is 'figure'.
+        an IPython environment, the mode is 'widget', otherwise it is 'figure'.
         If 'figure' is used, all plotly figures are wrapped as FigureResampler objects.
         If 'widget' is used, all plotly figure widgets are wrapped as
-        FigureWidgetResampler objects (we advise to use this mode in ipython environment
+        FigureWidgetResampler objects (we advise to use this mode in IPython environment
         with a kernel).
         If None is used, wrapping is done as expected (go.Figure -> FigureResampler,
         go.FigureWidget -> FigureWidgetResampler).

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -343,7 +343,7 @@ def test_nan_removed_input(float_series):
     )
 
     float_series = float_series.copy()
-    float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
+    float_series.iloc[np.random.choice(len(float_series), 100, replace=False)] = np.nan
     fig.add_trace(
         go.Scatter(x=float_series.index, y=float_series, name="float_series"),
         row=1,
@@ -351,6 +351,9 @@ def test_nan_removed_input(float_series):
         hf_text="text",
         hf_hovertext="hovertext",
     )
+    # Check the desired behavior
+    assert len(fig.hf_data[0]["y"]) == len(float_series) - 100
+    assert ~pd.isna(fig.hf_data[0]["y"]).any()
 
     # here we test whether we are able to deal with not-nan output
     float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
@@ -373,6 +376,37 @@ def test_nan_removed_input(float_series):
         row=1,
         col=2,
     )
+
+def test_nan_removed_input_check_nans_false(float_series):
+    # see: https://plotly.com/python/subplots/#custom-sized-subplot-with-subplot-titles
+    base_fig = make_subplots(
+        rows=2,
+        cols=2,
+        specs=[[{}, {}], [{"colspan": 2}, None]],
+    )
+
+    fig = FigureResampler(
+        base_fig,
+        default_n_shown_samples=1000,
+        resampled_trace_prefix_suffix=(
+            '<b style="color:sandybrown">[R]</b>',
+            '<b style="color:sandybrown">[R]</b>',
+        ),
+    )
+
+    float_series = float_series.copy()
+    float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
+    fig.add_trace(
+        go.Scatter(x=float_series.index, y=float_series, name="float_series"),
+        row=1,
+        col=1,
+        hf_text="text",
+        hf_hovertext="hovertext",
+        check_nans=False
+    )
+    # Check the undesired behavior
+    assert len(fig.hf_data[0]["y"]) == len(float_series)
+    assert pd.isna(fig.hf_data[0]["y"]).any()
 
 
 def test_hf_text():

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -263,7 +263,7 @@ def test_nan_removed_input(float_series):
     )
 
     float_series = float_series.copy()
-    float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
+    float_series.iloc[np.random.choice(len(float_series), 100, replace=False)] = np.nan
     fig.add_trace(
         go.Scatter(x=float_series.index, y=float_series, name="float_series"),
         row=1,
@@ -271,6 +271,9 @@ def test_nan_removed_input(float_series):
         hf_text="text",
         hf_hovertext="hovertext",
     )
+    # Check the desired behavior
+    assert len(fig.hf_data[0]["y"]) == len(float_series) - 100
+    assert ~pd.isna(fig.hf_data[0]["y"]).any()
 
     # here we test whether we are able to deal with not-nan output
     float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
@@ -293,6 +296,38 @@ def test_nan_removed_input(float_series):
         row=1,
         col=2,
     )
+
+
+def test_nan_removed_input_check_nans_false(float_series):
+    # see: https://plotly.com/python/subplots/#custom-sized-subplot-with-subplot-titles
+    base_fig = make_subplots(
+        rows=2,
+        cols=2,
+        specs=[[{}, {}], [{"colspan": 2}, None]],
+    )
+
+    fig = FigureWidgetResampler(
+        base_fig,
+        default_n_shown_samples=1000,
+        resampled_trace_prefix_suffix=(
+            '<b style="color:sandybrown">[R]</b>',
+            '<b style="color:sandybrown">[R]</b>',
+        ),
+    )
+
+    float_series = float_series.copy()
+    float_series.iloc[np.random.choice(len(float_series), 100)] = np.nan
+    fig.add_trace(
+        go.Scatter(x=float_series.index, y=float_series, name="float_series"),
+        row=1,
+        col=1,
+        hf_text="text",
+        hf_hovertext="hovertext",
+        check_nans=False
+    )
+    # Check the undesired behavior
+    assert len(fig.hf_data[0]["y"]) == len(float_series)
+    assert pd.isna(fig.hf_data[0]["y"]).any()
 
 
 def test_hf_text():
@@ -794,6 +829,7 @@ def test_hf_data_subplots_non_shared_xaxes_row_col_none():
     x_1 = fwr.data[1]['x']
     assert 40_000 <= x_1[0] <= 40_000 + (20_000 / 1000)  
     assert (60_000 - 20_000 / 1_000) <= x_1[-1] <= 60_000
+
 
 def test_updates_two_traces():
     n = 1_000_000


### PR DESCRIPTION
Checking for NaNs is a major bottleneck in graph construction time. This flag gives the user control to disable this check, which should be used when the user is sure that
(a) the data contains no NaNs, or
(b) the downsampler can handle NaNs (e.g., EveryNthPoint)