### PR TITLE
:art: formatting + linting in CI-CD

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+    - name: Cache poetry
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pypoetry/virtualenvs
+        key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}-python-${{ matrix.python-version }}
+    - run: poetry --version
+    - name: Install dependencies
+      run: poetry install
+      # Do not use caching (anymore)
+#      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+    - name: Lint
+      run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install Poetry
       uses: snok/install-poetry@v1
     - name: Cache poetry

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv*
 .cache_datasets/
+*.ruff*
 *.DS_Store
 file_system_store/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,12 +79,30 @@ poetry build  # build the underlying C code
 
 </details>
 
+### Formatting the code
+
+We use [black](https://github.com/psf/black) and [isort](https://github.com/PyCQA/isort) to format the code.
+
+To format the code, run the following command (more details in the [Makefile](Makefile)):
+```sh
+make format
+```
+
+### Checking the linting
+
+We use [ruff](https://github.com/charliermarsh/ruff) to check the linting.
+
+To check the linting, run the following command (more details in the [Makefile](Makefile)):
+```sh
+make lint
+```
+
 ### Running the tests (& code coverage)
 
-You can run the test with the following code:
+You can run the tests with the following code (more details in the [Makefile](Makefile)):
 
 ```sh
-poetry run pytest --cov-report term-missing --cov=plotly_resampler tests
+make test
 ```
 
 To get the selenium tests working you should have Google Chrome installed.

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ format:
 .PHONY: lint
 lint:
 	poetry run ruff plotly_resampler tests
-	$(isort) --check-only --df
-	$(black) --check --diff
+	poetry run $(isort) --check-only --df
+	poetry run $(black) --check --diff
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+black = black plotly_resampler examples tests
+isort = isort plotly_resampler examples tests
+
+.PHONY: format
+format:
+	$(isort)
+	$(black)
+
+.PHONY: lint
+lint:
+	ruff plotly_resampler tests
+	$(isort) --check-only --df
+	$(black) --check --diff
+
+.PHONY: test
+test:
+	poetry run pytest --cov-report term-missing --cov=plotly_resampler tests
+
+.PHONY: clean
+clean:
+	rm -rf `find . -name __pycache__`
+	rm -rf .cache
+	rm -rf .pytest_cache
+	rm -rf *.egg-info
+	rm -f .coverage
+	rm -rf build
+
+	rm -f `find . -type f -name '*.py[co]' `
+	rm -f `find . -type f -name '*~' `
+	rm -f `find . -type f -name '.*~' `
+	rm -f `find . -type f -name '*.cpython-*' `

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:
 
 .PHONY: lint
 lint:
-	ruff plotly_resampler tests
+	poetry run ruff plotly_resampler tests
 	$(isort) --check-only --df
 	$(black) --check --diff
 

--- a/examples/dash_apps/01_minimal_global.py
+++ b/examples/dash_apps/01_minimal_global.py
@@ -15,10 +15,10 @@ source: https://dash.plotly.com/sharing-data-between-callbacks:
 
 import numpy as np
 import plotly.graph_objects as go
-from dash import Input, Output, dcc, html, Dash, no_update, callback_context
+from dash import Dash, Input, Output, callback_context, dcc, html, no_update
+from trace_updater import TraceUpdater
 
 from plotly_resampler import FigureResampler
-from trace_updater import TraceUpdater
 
 # Data that will be used for the plotly-resampler figures
 x = np.arange(2_000_000)
@@ -38,7 +38,6 @@ app.layout = html.Div(
         html.H1("plotly-resampler global variable", style={"textAlign": "center"}),
         html.Button("plot chart", id="plot-button", n_clicks=0),
         html.Hr(),
-
         # The graph and it's needed components to update efficiently
         dcc.Graph(id="graph-id"),
         TraceUpdater(id="trace-updater", gdID="graph-id"),
@@ -59,8 +58,8 @@ def plot_graph(n_clicks):
         # Note how the replace method is used here on the global figure object
         global fig
         fig.replace(go.Figure())
-        fig.add_trace(go.Scattergl(name="log"), hf_x=x, hf_y=noisy_sin * .9999995 ** x)
-        fig.add_trace(go.Scattergl(name="exp"), hf_x=x, hf_y=noisy_sin * 1.000002 ** x)
+        fig.add_trace(go.Scattergl(name="log"), hf_x=x, hf_y=noisy_sin * 0.9999995**x)
+        fig.add_trace(go.Scattergl(name="exp"), hf_x=x, hf_y=noisy_sin * 1.000002**x)
         return fig
     else:
         return no_update

--- a/examples/dash_apps/02_minimal_cache.py
+++ b/examples/dash_apps/02_minimal_cache.py
@@ -11,14 +11,15 @@ variable is used and shows the best practice of using plotly-resampler within da
 
 import numpy as np
 import plotly.graph_objects as go
-from dash import Input, Output, State, dcc, html, no_update, callback_context
+from dash import Input, Output, State, callback_context, dcc, html, no_update
 from dash_extensions.enrich import (
     DashProxy,
     ServersideOutput,
     ServersideOutputTransform,
 )
-from plotly_resampler import FigureResampler
 from trace_updater import TraceUpdater
+
+from plotly_resampler import FigureResampler
 
 # Data that will be used for the plotly-resampler figures
 x = np.arange(2_000_000)

--- a/examples/dash_apps/03_minimal_cache_dynamic.py
+++ b/examples/dash_apps/03_minimal_cache_dynamic.py
@@ -13,8 +13,8 @@ chained together using the dcc.Interval component.
 
 """
 
-from uuid import uuid4
 from typing import List
+from uuid import uuid4
 
 import numpy as np
 import plotly.graph_objects as go
@@ -26,8 +26,9 @@ from dash_extensions.enrich import (
     Trigger,
     TriggerTransform,
 )
-from plotly_resampler import FigureResampler
 from trace_updater import TraceUpdater
+
+from plotly_resampler import FigureResampler
 
 # Data that will be used for the plotly-resampler figures
 x = np.arange(2_000_000)

--- a/examples/dash_apps/11_sine_generator.py
+++ b/examples/dash_apps/11_sine_generator.py
@@ -14,10 +14,10 @@ construct the plotly-resampler figure and cache it on the server side.
 
 from uuid import uuid4
 
+import dash_bootstrap_components as dbc
 import numpy as np
 import plotly.graph_objects as go
-import dash_bootstrap_components as dbc
-from dash import MATCH, Input, Output, State, dcc, html, no_update, callback_context
+from dash import MATCH, Input, Output, State, callback_context, dcc, html, no_update
 from dash_extensions.enrich import (
     DashProxy,
     ServersideOutput,
@@ -25,8 +25,9 @@ from dash_extensions.enrich import (
     Trigger,
     TriggerTransform,
 )
-from plotly_resampler import FigureResampler
 from trace_updater import TraceUpdater
+
+from plotly_resampler import FigureResampler
 
 # --------------------------------------Globals ---------------------------------------
 app = DashProxy(

--- a/examples/dash_apps/12_file_selector.py
+++ b/examples/dash_apps/12_file_selector.py
@@ -12,18 +12,17 @@ from typing import List
 
 import dash_bootstrap_components as dbc
 import plotly.graph_objects as go
-from dash import Input, Output, State, dcc, html, no_update, callback_context
-
+from dash import Input, Output, State, callback_context, dcc, html, no_update
 from dash_extensions.enrich import (
     DashProxy,
     ServersideOutput,
     ServersideOutputTransform,
 )
-from plotly_resampler import FigureResampler
 from trace_updater import TraceUpdater
-
-from utils.callback_helpers import multiple_folder_file_selector, get_selector_states
+from utils.callback_helpers import get_selector_states, multiple_folder_file_selector
 from utils.graph_construction import visualize_multiple_files
+
+from plotly_resampler import FigureResampler
 
 # --------------------------------------Globals ---------------------------------------
 app = DashProxy(

--- a/examples/dash_apps/13_coarse_fine.py
+++ b/examples/dash_apps/13_coarse_fine.py
@@ -13,23 +13,22 @@ TODO: add an rectangle on the coarse graph
 
 __author__ = "Jonas Van Der Donckt"
 
-import dash_bootstrap_components as dbc
-import plotly.graph_objects as go
 from pathlib import Path
 from typing import List
-from dash import Input, Output, State, dcc, html, no_update, callback_context
 
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import Input, Output, State, callback_context, dcc, html, no_update
 from dash_extensions.enrich import (
     DashProxy,
     ServersideOutput,
     ServersideOutputTransform,
 )
+from trace_updater import TraceUpdater
+from utils.callback_helpers import get_selector_states, multiple_folder_file_selector
+from utils.graph_construction import visualize_multiple_files
 
 from plotly_resampler import FigureResampler
-from trace_updater import TraceUpdater
-
-from utils.callback_helpers import multiple_folder_file_selector, get_selector_states
-from utils.graph_construction import visualize_multiple_files
 
 # --------------------------------------Globals ---------------------------------------
 app = DashProxy(

--- a/examples/dash_apps/utils/callback_helpers.py
+++ b/examples/dash_apps/utils/callback_helpers.py
@@ -3,10 +3,10 @@
 
 __author__ = "Jonas Van Der Donckt"
 
+import itertools
 from pathlib import Path
 from typing import Dict, List
 
-import itertools
 import dash_bootstrap_components as dbc
 from dash import Input, Output, State, dcc, html
 from functional import seq
@@ -21,8 +21,8 @@ def _update_file_widget(folder):
             set(
                 list(
                     seq(Path(folder).iterdir())
-                        .filter(lambda x: x.is_file() and x.name.endswith("parquet"))
-                        .map(lambda x: x.name)
+                    .filter(lambda x: x.is_file() and x.name.endswith("parquet"))
+                    .map(lambda x: x.name)
                 )
             )
         )
@@ -41,7 +41,7 @@ def _register_selection_callbacks(app, ids=None):
 
 
 def multiple_folder_file_selector(
-        app, name_folders_list: List[Dict[str, dict]], multi=True
+    app, name_folders_list: List[Dict[str, dict]], multi=True
 ) -> dbc.Card:
     """Constructs a folder user date selector
 

--- a/examples/other_apps/streamlit_app.py
+++ b/examples/other_apps/streamlit_app.py
@@ -13,30 +13,31 @@ $ streamlit run streamlit_app.py
 
 __author__ = "Jeroen Van Der Donckt"
 
-import plotly.graph_objects as go
-from plotly_resampler import FigureResampler
-
 # 0. Create a noisy sine wave
 import numpy as np
+import plotly.graph_objects as go
+
+from plotly_resampler import FigureResampler
+
 x = np.arange(1_000_000)
 noisy_sin = (3 + np.sin(x / 200) + np.random.randn(len(x)) / 10) * x / 1_000
 
 ### 1. Use FigureResampler
 fig = FigureResampler(default_n_shown_samples=2_000)
-fig.add_trace(go.Scattergl(name='noisy sine', showlegend=True), hf_x=x, hf_y=noisy_sin)
+fig.add_trace(go.Scattergl(name="noisy sine", showlegend=True), hf_x=x, hf_y=noisy_sin)
 fig.update_layout(height=700)
 
 ### 2. Run the visualization (which is a dash app) in a (sub)process on a certain port
 # Note: starting a process allows executing code after `.show_dash` is called
 from multiprocessing import Process
+
 port = 9022
-proc = Process(
-    target=fig.show_dash, kwargs=dict(mode="external", port=port)
-).start()
+proc = Process(target=fig.show_dash, kwargs=dict(mode="external", port=port)).start()
 
 # Deleting the lines below this and running this file will result in a classic running dash app
 # Note: for just a dash app it is not even necessary to execute .show_dash in a (sub)process
 
 ### 3. Add as iframe component to streamlit
 import streamlit.components.v1 as components
-components.iframe(f'http://localhost:{port}', height=700)
+
+components.iframe(f"http://localhost:{port}", height=700)

--- a/plotly_resampler/aggregation/aggregation_interface.py
+++ b/plotly_resampler/aggregation/aggregation_interface.py
@@ -29,14 +29,14 @@ class AbstractSeriesAggregator(ABC):
             irregularly sampled data. By default, True.
         nan_position: str, optional
             Indicates where nans must be placed when gaps are detected. \n
-            If ``'end'``, the first point after a gap will be replaced with a 
+            If ``'end'``, the first point after a gap will be replaced with a
             nan-value \n
-            If ``'begin'``, the last point before a gap will be replaced with a 
+            If ``'begin'``, the last point before a gap will be replaced with a
             nan-value \n
-            If ``'both'``, both the encompassing gap datapoints are replaced with 
+            If ``'both'``, both the encompassing gap datapoints are replaced with
             nan-values \n
             .. note::
-                This parameter only has an effect when ``interleave_gaps`` is set 
+                This parameter only has an effect when ``interleave_gaps`` is set
                 to *True*.
         dtype_regex_list: List[str], optional
             List containing the regex matching the supported datatypes, by default None.

--- a/plotly_resampler/aggregation/aggregators.py
+++ b/plotly_resampler/aggregation/aggregators.py
@@ -21,6 +21,7 @@ try:
     from .algorithms.lttb_c import LTTB_core_c as LTTB_core
 except (ImportError, ModuleNotFoundError):
     import warnings
+
     warnings.warn("Could not import lttbc; will use a (slower) python alternative.")
     from .algorithms.lttb_py import LTTB_core_py as LTTB_core
 
@@ -286,7 +287,7 @@ class EfficientLTTB(AbstractSeriesAggregator):
         ratio_threshold = 100
 
         # TODO -> test this with a move of the .so file
-        if LTTB_core.__name__ == 'LTTB_core_py':
+        if LTTB_core.__name__ == "LTTB_core_py":
             size_threshold = 1_000_000
 
         if s.shape[0] > size_threshold and s.shape[0] / n_out > ratio_threshold:

--- a/plotly_resampler/aggregation/algorithms/lttb_c.py
+++ b/plotly_resampler/aggregation/algorithms/lttb_c.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+
 from .lttbc import (
     downsample_double_double,
     downsample_int_double,

--- a/plotly_resampler/figure_resampler/__init__.py
+++ b/plotly_resampler/figure_resampler/__init__.py
@@ -13,7 +13,6 @@ The term `high-frequency` actually refers very large amounts of sequential data.
 from .figure_resampler import FigureResampler
 from .figurewidget_resampler import FigureWidgetResampler
 
-
 __all__ = [
     "FigureResampler",
     "FigureWidgetResampler",

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
-import warnings
-from typing import Tuple, List
-
-import uuid
 import base64
+import uuid
+import warnings
+from typing import List, Tuple
+
 import dash
 import plotly.graph_objects as go
 from flask_cors import cross_origin

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -13,21 +13,20 @@ from __future__ import annotations
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
 import re
+from abc import ABC
+from collections import namedtuple
 from copy import copy
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 from uuid import uuid4
-from collections import namedtuple
 
 import dash
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-from plotly.basedatatypes import BaseTraceType, BaseFigure
+from plotly.basedatatypes import BaseFigure, BaseTraceType
 
 from ..aggregation import AbstractSeriesAggregator, EfficientLTTB
-from .utils import round_td_str, round_number_str
-
-from abc import ABC
+from .utils import round_number_str, round_td_str
 
 _hf_data_container = namedtuple("DataContainer", ["x", "y", "text", "hovertext"])
 
@@ -641,7 +640,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             if isinstance(hf_y, (pd.Series, pd.Index))
             else hf_y
         )
-        hf_y : np.ndarray = np.asarray(hf_y)
+        hf_y: np.ndarray = np.asarray(hf_y)
 
         hf_text = (
             hf_text
@@ -696,9 +695,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
                     hf_hovertext = hf_hovertext[not_nan_mask]
 
             # Try to parse the hf_x data if it is of object type or
-            if len(hf_x) and (
-                hf_x.dtype.type is np.str_ or hf_x.dtype == "object"
-            ):  
+            if len(hf_x) and (hf_x.dtype.type is np.str_ or hf_x.dtype == "object"):
                 try:
                     # Try to parse to numeric
                     hf_x = pd.to_numeric(hf_x, errors="raise")
@@ -901,7 +898,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             As this is a costly operation, it is recommended to set this parameter to
             False if you are sure that your data does not contain NaNs (or when the
             downsampler can handle NaNs, e.g., EveryNthPoint). This should considerably
-            speed up the graph construction time. 
+            speed up the graph construction time.
         **trace_kwargs: dict
             Additional trace related keyword arguments.
             e.g.: row=.., col=..., secondary_y=...
@@ -973,7 +970,9 @@ class AbstractFigureAggregator(BaseFigure, ABC):
 
         # construct the hf_data_container
         # TODO in future version -> maybe regex on kwargs which start with `hf_`
-        dc = self._parse_get_trace_props(trace, hf_x, hf_y, hf_text, hf_hovertext, check_nans)
+        dc = self._parse_get_trace_props(
+            trace, hf_x, hf_y, hf_text, hf_hovertext, check_nans
+        )
 
         # These traces will determine the autoscale its RANGE!
         #   -> so also store when `limit_to_view` is set.
@@ -1069,7 +1068,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
         limit_to_views : None | List[bool] | bool, optional
             List of limit_to_view booleans for the added traces. If set to True the
             trace's datapoints will be cut to the corresponding front-end view, even if
-            the total number of samples is lower than ``max_n_samples``. 
+            the total number of samples is lower than ``max_n_samples``.
             If a single boolean is passed, all to be added traces will use this value,
             by default False.\n
             Remark that setting this parameter to True ensures that low frequency traces

--- a/plotly_resampler/figure_resampler/figurewidget_resampler.py
+++ b/plotly_resampler/figure_resampler/figurewidget_resampler.py
@@ -66,7 +66,7 @@ class FigureWidgetResampler(
             f._grid_ref = figure._grid_ref
             f.add_traces(figure.data)
         elif isinstance(figure, dict) and (
-            "data" in figure or "layout" in figure # or "frames" in figure  # TODO
+            "data" in figure or "layout" in figure  # or "frames" in figure  # TODO
         ):
             # A figure as a dict, can be;
             # - a plotly figure as a dict (after calling `fig.to_dict()`)

--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -1,10 +1,11 @@
 """Utility functions for the figure_resampler submodule."""
 
 import math
-import pandas as pd
 
+import pandas as pd
 from plotly.basedatatypes import BaseFigure
-try: # Fails when IPywidgets is not installed
+
+try:  # Fails when IPywidgets is not installed
     from plotly.basewidget import BaseFigureWidget
 except (ImportError, ModuleNotFoundError):
     BaseFigureWidget = type(None)

--- a/plotly_resampler/registering.py
+++ b/plotly_resampler/registering.py
@@ -2,13 +2,14 @@
 
 __author__ = "Jeroen Van Der Donckt, Jonas Van Der Donckt, Emiel Deprost"
 
+from functools import wraps
+
+import plotly
+
 from plotly_resampler import FigureResampler, FigureWidgetResampler
 from plotly_resampler.figure_resampler.figure_resampler_interface import (
     AbstractFigureAggregator,
 )
-from functools import wraps
-
-import plotly
 
 WRAPPED_PREFIX = "[Plotly-Resampler]__"
 PLOTLY_MODULES = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = ">=3.6"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-docs = ["setuptools-scm", "sphinx", "sphinx-rtd-theme"]
+docs = ["sphinx", "setuptools-scm", "sphinx-rtd-theme"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
@@ -42,8 +42,8 @@ argon2-cffi-bindings = "*"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-dev = ["cogapp", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "pre-commit", "pytest", "sphinx", "sphinx-notfound-page", "tomli"]
-docs = ["furo", "sphinx", "sphinx-notfound-page"]
+dev = ["pre-commit", "cogapp", "tomli", "coverage[toml] (>=5.0.2)", "hypothesis", "pytest", "sphinx", "sphinx-notfound-page", "furo"]
+docs = ["sphinx", "sphinx-notfound-page", "furo"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
@@ -58,7 +58,7 @@ python-versions = ">=3.6"
 cffi = ">=1.0.1"
 
 [package.extras]
-dev = ["cogapp", "pre-commit", "pytest", "wheel"]
+dev = ["pytest", "cogapp", "pre-commit", "wheel"]
 tests = ["pytest"]
 
 [[package]]
@@ -86,10 +86,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "babel"
@@ -162,7 +162,7 @@ webencodings = "*"
 
 [package.extras]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
-dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "mypy (==0.961)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)"]
+dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "Sphinx (==4.3.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)", "black (==22.3.0)", "mypy (==0.961)"]
 
 [[package]]
 name = "blinker"
@@ -257,11 +257,11 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "dash"
@@ -280,11 +280,11 @@ flask-compress = "*"
 plotly = ">=5.0.0"
 
 [package.extras]
-celery = ["celery[redis] (>=5.1.2)", "redis (>=3.5.3)"]
-ci = ["black (==21.6b0)", "black (==22.3.0)", "dash-dangerously-set-inner-html", "dash-flow-example (==0.0.5)", "flake8 (==3.9.2)", "flaky (==3.7.0)", "flask-talisman (==1.0.0)", "isort (==4.3.21)", "mimesis", "mock (==4.0.3)", "numpy", "openpyxl", "orjson (==3.5.4)", "orjson (==3.6.7)", "pandas (==1.1.5)", "pandas (>=1.4.0)", "preconditions", "pyarrow", "pyarrow (<3)", "pylint (==2.13.5)", "pytest-mock", "pytest-rerunfailures", "pytest-sugar (==0.9.4)", "xlrd (<2)", "xlrd (>=2.0.1)"]
-dev = ["PyYAML (>=5.4.1)", "coloredlogs (>=15.0.1)", "fire (>=0.4.0)"]
+celery = ["redis (>=3.5.3)", "celery[redis] (>=5.1.2)"]
+ci = ["dash-flow-example (==0.0.5)", "dash-dangerously-set-inner-html", "flake8 (==3.9.2)", "flaky (==3.7.0)", "flask-talisman (==1.0.0)", "mimesis", "mock (==4.0.3)", "numpy", "preconditions", "pylint (==2.13.5)", "pytest-mock", "pytest-sugar (==0.9.4)", "pytest-rerunfailures", "black (==21.6b0)", "isort (==4.3.21)", "orjson (==3.5.4)", "pyarrow (<3)", "pandas (==1.1.5)", "xlrd (<2)", "black (==22.3.0)", "orjson (==3.6.7)", "pyarrow", "openpyxl", "pandas (>=1.4.0)", "xlrd (>=2.0.1)"]
+dev = ["coloredlogs (>=15.0.1)", "fire (>=0.4.0)", "PyYAML (>=5.4.1)"]
 diskcache = ["diskcache (>=5.2.1)", "multiprocess (>=0.70.12)", "psutil (>=5.8.0)"]
-testing = ["beautifulsoup4 (>=4.8.2)", "cryptography (<3.4)", "lxml (>=4.6.2)", "percy (>=2.0.2)", "pytest (>=6.0.2)", "requests[security] (>=2.21.0)", "selenium (>=3.141.0)", "waitress (>=1.4.4)"]
+testing = ["beautifulsoup4 (>=4.8.2)", "lxml (>=4.6.2)", "percy (>=2.0.2)", "pytest (>=6.0.2)", "requests[security] (>=2.21.0)", "selenium (>=3.141.0)", "waitress (>=1.4.4)", "cryptography (<3.4)"]
 
 [[package]]
 name = "dash-core-components"
@@ -359,7 +359,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
+devel = ["colorama", "jsonschema", "json-spec", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
 
 [[package]]
 name = "flask"
@@ -472,9 +472,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -488,8 +488,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -521,7 +521,7 @@ tornado = ">=6.1"
 traitlets = ">=5.1.0"
 
 [package.extras]
-test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=6.0)", "pytest-cov", "pytest-timeout"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest-cov", "pytest-timeout", "pytest (>=6.0)"]
 
 [[package]]
 name = "ipython"
@@ -550,10 +550,10 @@ doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
 nbformat = ["nbformat"]
-notebook = ["ipywidgets", "notebook"]
+notebook = ["notebook", "ipywidgets"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["ipykernel", "nbformat", "nose (>=0.10.1)", "numpy (>=1.17)", "pygments", "requests", "testpath"]
+test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.17)"]
 
 [[package]]
 name = "ipython-genutils"
@@ -580,7 +580,21 @@ traitlets = ">=4.3.1"
 widgetsnbextension = ">=3.6.0,<3.7.0"
 
 [package.extras]
-test = ["mock", "pytest (>=3.6.0)", "pytest-cov"]
+test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "itsdangerous"
@@ -656,7 +670,7 @@ tornado = ">=6.0"
 traitlets = "*"
 
 [package.extras]
-doc = ["ipykernel", "myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+doc = ["ipykernel", "myst-parser", "sphinx-rtd-theme", "sphinx (>=1.3.6)", "sphinxcontrib-github-alt"]
 test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
@@ -693,7 +707,7 @@ requests = "*"
 retrying = "*"
 
 [package.extras]
-dev = ["jupyter-server-proxy", "jupyterlab (>=2.0)", "notebook (>=6.0)"]
+dev = ["jupyter-server-proxy", "notebook (>=6.0)", "jupyterlab (>=2.0)"]
 
 [[package]]
 name = "jupyterlab-pygments"
@@ -736,10 +750,10 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-all = ["IPython (>=0.13)", "IPython (>=0.13,<7.17.0)", "cmake", "coverage[toml] (>=5.3)", "cython", "ninja", "pytest (>=4.6.11)", "pytest-cov (>=2.10.1)", "scikit-build", "ubelt (>=1.0.1)"]
-build = ["cmake", "cython", "ninja", "scikit-build"]
-ipython = ["IPython (>=0.13)", "IPython (>=0.13,<7.17.0)"]
-tests = ["IPython (>=0.13)", "IPython (>=0.13,<7.17.0)", "coverage[toml] (>=5.3)", "pytest (>=4.6.11)", "pytest-cov (>=2.10.1)", "ubelt (>=1.0.1)"]
+all = ["cython", "scikit-build", "cmake", "ninja", "pytest (>=4.6.11)", "pytest-cov (>=2.10.1)", "coverage[toml] (>=5.3)", "ubelt (>=1.0.1)", "IPython (>=0.13,<7.17.0)", "IPython (>=0.13)"]
+build = ["cython", "scikit-build", "cmake", "ninja"]
+ipython = ["IPython (>=0.13,<7.17.0)", "IPython (>=0.13)"]
+tests = ["pytest (>=4.6.11)", "pytest-cov (>=2.10.1)", "coverage[toml] (>=5.3)", "ubelt (>=1.0.1)", "IPython (>=0.13,<7.17.0)", "IPython (>=0.13)"]
 
 [[package]]
 name = "markupsafe"
@@ -802,7 +816,7 @@ nest-asyncio = "*"
 traitlets = ">=5.2.2"
 
 [package.extras]
-sphinx = ["Sphinx (>=1.7)", "autodoc-traits", "mock", "moto", "myst-parser", "sphinx-book-theme"]
+sphinx = ["autodoc-traits", "mock", "moto", "myst-parser", "Sphinx (>=1.7)", "sphinx-book-theme"]
 test = ["black", "check-manifest", "flake8", "ipykernel", "ipython (<8.0.0)", "ipywidgets (<8.0.0)", "mypy", "pip (>=18.1)", "pre-commit", "pytest (>=4.1)", "pytest-asyncio", "pytest-cov (>=2.6.1)", "setuptools (>=60.0)", "testpath", "twine (>=1.11.0)", "xmltodict"]
 
 [[package]]
@@ -832,10 +846,10 @@ tinycss2 = "*"
 traitlets = ">=5.0"
 
 [package.extras]
-all = ["ipykernel", "ipython", "ipywidgets (>=7)", "nbsphinx (>=0.2.12)", "pre-commit", "pyppeteer (>=1,<1.1)", "pytest", "pytest-cov", "pytest-dependency", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "tornado (>=6.1)"]
-docs = ["ipython", "nbsphinx (>=0.2.12)", "sphinx (>=1.5.1)", "sphinx-rtd-theme"]
+all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "tornado (>=6.1)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
 serve = ["tornado (>=6.1)"]
-test = ["ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "pytest", "pytest-cov", "pytest-dependency"]
+test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)"]
 webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
@@ -853,7 +867,7 @@ jupyter-core = "*"
 traitlets = ">=5.1"
 
 [package.extras]
-test = ["check-manifest", "pre-commit", "pytest", "testpath"]
+test = ["check-manifest", "testpath", "pytest", "pre-commit"]
 
 [[package]]
 name = "nest-asyncio"
@@ -889,9 +903,9 @@ tornado = ">=6.1"
 traitlets = ">=4.2.1"
 
 [package.extras]
-docs = ["myst-parser", "nbsphinx", "sphinx", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+docs = ["sphinx", "nbsphinx", "sphinxcontrib-github-alt", "sphinx-rtd-theme", "myst-parser"]
 json-logging = ["json-logging"]
-test = ["coverage", "nbval", "pytest", "pytest-cov", "requests", "requests-unixsocket", "selenium", "testpath"]
+test = ["pytest", "coverage", "requests", "testpath", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
 name = "numpy"
@@ -1008,8 +1022,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "plotly"
@@ -1034,8 +1048,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
 
 [[package]]
 name = "prometheus-client"
@@ -1068,7 +1082,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "ptyprocess"
@@ -1140,10 +1154,10 @@ packaging = "*"
 sphinx = ">=4.0.2"
 
 [package.extras]
-coverage = ["codecov", "pydata-sphinx-theme", "pytest-cov"]
-dev = ["nox", "pre-commit", "pydata-sphinx-theme", "pyyaml"]
-doc = ["jupyter-sphinx", "myst-parser", "numpy", "numpydoc", "pandas", "plotly", "pytest", "pytest-regressions", "sphinx-design", "sphinx-sitemap", "sphinxext-rediraffe", "xarray"]
+dev = ["pydata-sphinx-theme", "nox", "pre-commit", "pyyaml"]
+coverage = ["pydata-sphinx-theme", "codecov", "pytest-cov"]
 test = ["pydata-sphinx-theme", "pytest"]
+doc = ["sphinx-design", "xarray", "numpy", "plotly", "jupyter-sphinx", "sphinx-sitemap", "sphinxext-rediraffe", "pytest-regressions", "pytest", "pandas", "myst-parser", "numpydoc"]
 
 [[package]]
 name = "pydivert"
@@ -1155,7 +1169,7 @@ python-versions = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.4.8)"]
-test = ["codecov (>=2.0.5)", "hypothesis (>=3.5.3)", "mock (>=1.0.1)", "pytest (>=3.0.3)", "pytest-cov (>=2.2.1)", "pytest-faulthandler (>=1.3.0,<2)", "pytest-timeout (>=1.0.0,<2)", "wheel (>=0.29)"]
+test = ["mock (>=1.0.1)", "hypothesis (>=3.5.3)", "pytest (>=3.0.3)", "pytest-cov (>=2.2.1)", "pytest-timeout (>=1.0.0,<2)", "pytest-faulthandler (>=1.3.0,<2)", "codecov (>=2.0.5)", "wheel (>=0.29)"]
 
 [[package]]
 name = "pygments"
@@ -1189,7 +1203,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyrsistent"
@@ -1227,7 +1241,7 @@ py = ">=1.8.2"
 toml = "*"
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["xmlschema", "requests", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
 
 [[package]]
 name = "pytest-base-url"
@@ -1254,7 +1268,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
 
 [[package]]
 name = "pytest-html"
@@ -1311,9 +1325,9 @@ python-versions = ">=3.7,<4.0"
 pytest = ">=3.0.0,<8.0.0"
 
 [package.extras]
-hjson = ["hjson"]
 toml = ["toml"]
 yaml = ["pyyaml"]
+hjson = ["hjson"]
 
 [[package]]
 name = "python-dateutil"
@@ -1411,6 +1425,14 @@ python-versions = "*"
 six = ">=1.7.0"
 
 [[package]]
+name = "ruff"
+version = "0.0.173"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "selenium"
 version = "4.2.0"
 description = ""
@@ -1448,7 +1470,7 @@ wsproto = ">=0.14"
 zstandard = ">=0.14.1"
 
 [package.extras]
-dev = ["black", "bumpversion", "coverage", "flake8", "gunicorn", "httpbin", "isort", "mitmproxy (>5.3.0)", "mypy", "pre-commit", "pytest", "pytest-cov", "tox", "twine", "werkzeug (==2.0.3)", "wheel"]
+dev = ["black", "bumpversion", "coverage", "flake8", "gunicorn", "httpbin", "isort", "mypy", "pre-commit", "pytest", "pytest-cov", "tox", "twine", "werkzeug (==2.0.3)", "wheel", "mitmproxy (>5.3.0)"]
 
 [[package]]
 name = "send2trash"
@@ -1532,8 +1554,8 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "types-requests", "types-typed-ast"]
-test = ["cython", "html5lib", "pytest", "pytest-cov", "typed-ast"]
+lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "docutils-stubs", "types-typed-ast", "types-requests"]
+test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
@@ -1559,8 +1581,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
+lint = ["docutils-stubs", "mypy", "flake8"]
 
 [[package]]
 name = "sphinxcontrib-devhelp"
@@ -1571,8 +1593,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
+lint = ["docutils-stubs", "mypy", "flake8"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
@@ -1583,8 +1605,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["html5lib", "pytest"]
+lint = ["docutils-stubs", "mypy", "flake8"]
 
 [[package]]
 name = "sphinxcontrib-jsmath"
@@ -1595,7 +1617,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["flake8", "mypy", "pytest"]
+test = ["mypy", "flake8", "pytest"]
 
 [[package]]
 name = "sphinxcontrib-qthelp"
@@ -1606,8 +1628,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
+lint = ["docutils-stubs", "mypy", "flake8"]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
@@ -1618,7 +1640,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
+lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
@@ -1649,7 +1671,7 @@ pywinpty = {version = ">=1.1.0", markers = "os_name == \"nt\""}
 tornado = ">=6.1.0"
 
 [package.extras]
-test = ["pre-commit", "pytest (>=6.0)", "pytest-timeout"]
+test = ["pre-commit", "pytest-timeout", "pytest (>=6.0)"]
 
 [[package]]
 name = "tinycss2"
@@ -1663,8 +1685,8 @@ python-versions = ">=3.6"
 webencodings = ">=0.4"
 
 [package.extras]
-doc = ["sphinx", "sphinx-rtd-theme"]
-test = ["coverage", "pytest", "pytest-cov", "pytest-flake8", "pytest-isort"]
+test = ["coverage", "pytest-isort", "pytest-flake8", "pytest-cov", "pytest"]
+doc = ["sphinx-rtd-theme", "sphinx"]
 
 [[package]]
 name = "toml"
@@ -1771,8 +1793,8 @@ pyOpenSSL = {version = ">=0.14", optional = true, markers = "extra == \"secure\"
 PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers = "extra == \"socks\""}
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -1846,8 +1868,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "zstandard"
@@ -1866,7 +1888,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1,<3.11"
-content-hash = "655f3139b689b760555992d82b401c08665fe8f8baef9d2e7c0f1fbcadc65603"
+content-hash = "55f6e775c6811e17a7b9b9f5d82fc19310a0275b6c75bd60c0c7465cb94d9c73"
 
 [metadata.files]
 alabaster = [
@@ -2304,6 +2326,10 @@ ipython-genutils = [
 ipywidgets = [
     {file = "ipywidgets-7.7.1-py2.py3-none-any.whl", hash = "sha256:aa1076ab7102b2486ae2607c43c243200a07c17d6093676c419d4b6762489a50"},
     {file = "ipywidgets-7.7.1.tar.gz", hash = "sha256:5f2fa1b7afae1af32c88088c9828ad978de93ddda393d7ed414e553fee93dcab"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 itsdangerous = [
     {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
@@ -2907,6 +2933,24 @@ requests = [
 ]
 retrying = [
     {file = "retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"},
+]
+ruff = [
+    {file = "ruff-0.0.173-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:b0d2078e7a6dce57b5ec85655bb5adcab902e21d71962eb289ec47fb8b162d61"},
+    {file = "ruff-0.0.173-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:fb80d57de8107c97afbddbc672727055f58e3d6ddd971731dee0142b06b7fff3"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d6512c348f2335dbfa45dfb9be55eda0adc080ece076e26923d2c8521deb955"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a905578c443657c8b9b9954cf9421dbd176b47af9d20474fd36c89e85f6881e6"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e544e704279e8f6e9f1940f2a5c039f2e524857b98b142ce34c8aa8df3cfa2ac"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2feb9d6ad80c61627e37c190ee021fe00681ae63ac93213b2c08a9b99e748299"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c20cc8ca68bfe52408b525d2e6fbf5247045966b1d3aa0a80e4c116de0ca2507"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5043c87e0b9c85c8940640d2d679e7dba3bb5e6c430efd0852525ae86db9d488"},
+    {file = "ruff-0.0.173-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fbca765e78ff888f1440eaacfe5a9301ff719cf70c270ee47c7f5c1ed603252"},
+    {file = "ruff-0.0.173-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:afa0e2d715e5eaae49b000aa96ed980b60acf72f4539b539da33a3f070b16eb8"},
+    {file = "ruff-0.0.173-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:429d7e86d70a42bef8bd55659643ca1ad4b3580dbed5451e3599caf90b65fc95"},
+    {file = "ruff-0.0.173-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ebaf9a050219e74d9e486e63a9c029a36eb33b3b53801691c5132cdd653c6380"},
+    {file = "ruff-0.0.173-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81d00777649f9008e14db07c6612441b44402e8656d908a94ba93483d36d77f2"},
+    {file = "ruff-0.0.173-py3-none-win32.whl", hash = "sha256:dc22d15bf3df7c851027eeda61ffd1f5878806819c3561bbbc3312b267a916c1"},
+    {file = "ruff-0.0.173-py3-none-win_amd64.whl", hash = "sha256:2e67731be3d7f81e9627476d965e43b898f0c69e71f4cab015b570a69fbbd6bb"},
+    {file = "ruff-0.0.173.tar.gz", hash = "sha256:89f41ff82cb33ae1888e7bd5bba67f55dc1c12eb8aa0dc77fa45ebd57943a0d0"},
 ]
 selenium = [
     {file = "selenium-4.2.0-py3-none-any.whl", hash = "sha256:ba5b2633f43cf6fe9d308fa4a6996e00a101ab9cb1aad6fd91ae1f3dbe57f56f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ Werkzeug = "<=2.1.2"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
-black = "^22.6.0"
 selenium = "4.2.0"
 pytest-selenium = "^2.0.1"
 webdriver-manager = "^3.5.2"
@@ -48,7 +47,32 @@ ipywidgets = "^7.7.1"
 memory-profiler = "^0.60.0"
 line-profiler = "^3.5.1"
 kaleido = "0.2.1"
+ruff = "^0.0.173"
+black = "^22.6.0"
+isort = "^5.10.1"
 # yep = "^0.4"  # c code profiling
+
+# Linting
+[tool.ruff]
+line-length = 88
+ignore = ["E501"] # Never enforce `E501` (line length violations).
+[tool.ruff.per-file-ignores]
+"tests/test_registering.py" = ["F401", "F811"]
+"tests/test_serialization.py" = ["F401", "F811"]
+
+# Formatting
+[tool.black]
+color = true
+line-length = 88
+
+# Sort imports
+[tool.isort]
+line_length = 88
+known_first_party = ["plotly_resampler"]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
 
 [build-system]
 requires = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,21 @@
 """Fixtures and helper functions for testing"""
 
 
+import os
 from typing import Union
 
-import os
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
 from plotly.subplots import make_subplots
 
-from plotly_resampler import FigureResampler, LTTB, EveryNthPoint, unregister_plotly_resampler
+from plotly_resampler import (
+    LTTB,
+    EveryNthPoint,
+    FigureResampler,
+    unregister_plotly_resampler,
+)
 
 # hyperparameters
 _nb_samples = 10_000
@@ -31,6 +36,7 @@ def _remove_file(file_path):
     if os.path.exists(file_path):
         os.remove(file_path)
 
+
 @pytest.fixture
 def pickle_figure():
     FIG_PATH = "fig.pkl"
@@ -41,17 +47,18 @@ def pickle_figure():
 
 @pytest.fixture
 def driver():
-    from seleniumwire import webdriver
-    from webdriver_manager.chrome import ChromeDriverManager, ChromeType
+    import time
+
     from selenium.webdriver.chrome.options import Options
     from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+    from seleniumwire import webdriver
+    from webdriver_manager.chrome import ChromeDriverManager, ChromeType
 
-    import time
     time.sleep(1)
-    
+
     options = Options()
     d = DesiredCapabilities.CHROME
-    d['goog:loggingPrefs'] = {'browser': 'ALL'}
+    d["goog:loggingPrefs"] = {"browser": "ALL"}
     if not TESTING_LOCAL:
         if headless:
             options.add_argument("--headless")

--- a/tests/fr_selenium.py
+++ b/tests/fr_selenium.py
@@ -15,20 +15,19 @@ import json
 import time
 from typing import List, Union
 
-from seleniumwire import webdriver
-from seleniumwire.request import Request
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from seleniumwire import webdriver
+from seleniumwire.request import Request
 
-# Note: this will be used to add more waiting time to windows & mac os tests as 
-# - on these OS's serialization of the figure is necessary (to start the dash app in a 
+# Note: this will be used to add more waiting time to windows & mac os tests as
+# - on these OS's serialization of the figure is necessary (to start the dash app in a
 #    multiprocessing.Process)
 #    https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
 # - on linux, the browser (i.e., sending & getting requests) goes a lot faster
 from .utils import not_on_linux
-
 
 # https://www.blazemeter.com/blog/improve-your-selenium-webdriver-tests-with-pytest
 # and create a parameterized driver.get method
@@ -152,7 +151,7 @@ class RequestParser:
 
 
 class FigureResamplerGUITests:
-    """Wrapper for performing figure-resampler GUI. """
+    """Wrapper for performing figure-resampler GUI."""
 
     def __init__(self, driver: webdriver, port: int):
         """Construct an instance of A firefox selenium driver to fetch wearable data.
@@ -178,13 +177,14 @@ class FigureResamplerGUITests:
         time.sleep(1)
         self.driver.get("http://localhost:{}".format(self.port))
         self.on_page = True
-        if not_on_linux(): time.sleep(7)  # bcs serialization of multiprocessing
+        if not_on_linux():
+            time.sleep(7)  # bcs serialization of multiprocessing
         max_nb_tries = 3
         for _ in range(max_nb_tries):
             try:
                 self.driver.find_element_by_id("resample-figure")
                 break
-            except:
+            except Exception:
                 time.sleep(5)
 
     def clear_requests(self, sleep_time_s=1):
@@ -192,7 +192,8 @@ class FigureResamplerGUITests:
         del self.driver.requests
 
     def get_requests(self, delete: bool = True):
-        if not_on_linux(): time.sleep(2)  # bcs slower browser 
+        if not_on_linux():
+            time.sleep(2)  # bcs slower browser
         requests = self.driver.requests
         if delete:
             self.clear_requests()

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,16 +1,18 @@
+import numpy as np
+import pandas as pd
+import pytest
+
 from plotly_resampler.aggregation import (
+    LTTB,
+    EfficientLTTB,
     EveryNthPoint,
     FuncAggregator,
-    LTTB,
-    MinMaxOverlapAggregator,
     MinMaxAggregator,
-    EfficientLTTB,
+    MinMaxOverlapAggregator,
 )
-from plotly_resampler.aggregation.algorithms.lttb_py import LTTB_core_py
 from plotly_resampler.aggregation.algorithms.lttb_c import LTTB_core_c
-import pandas as pd
-import numpy as np
-import pytest
+from plotly_resampler.aggregation.algorithms.lttb_py import LTTB_core_py
+
 
 # --------------------------------- EveryNthPoint ------------------------------------
 def test_every_nth_point_float_time_data(float_series):
@@ -90,7 +92,7 @@ def test_every_nth_point_bool_sequence_data(bool_series):
 
 
 def test_every_nth_point_empty_series():
-    empty_series = pd.Series(name="empty", dtype='float32')
+    empty_series = pd.Series(name="empty", dtype="float32")
     out = EveryNthPoint(interleave_gaps=True).aggregate(empty_series, n_out=1_000)
     assert out.equals(empty_series)
 
@@ -232,7 +234,7 @@ def test_mmo_bool_sequence_data(bool_series):
 
 
 def test_mmo_empty_series():
-    empty_series = pd.Series(name="empty", dtype='float32')
+    empty_series = pd.Series(name="empty", dtype="float32")
     out = MinMaxOverlapAggregator(interleave_gaps=True).aggregate(
         empty_series, n_out=1_000
     )
@@ -646,7 +648,7 @@ def test_func_aggregator_invalid_input_data(cat_series):
 
 # ------------------------------- LTTB_Bindings -------------------------------
 def test_lttb_bindings():
-    # Test whether both algorithms produce the same results with different types of 
+    # Test whether both algorithms produce the same results with different types of
     # input data
     n = np.random.randint(low=1_000_000, high=2_000_000)
     x_int = np.arange(n, dtype="int64")

--- a/tests/test_composability.py
+++ b/tests/test_composability.py
@@ -1,8 +1,7 @@
-from random import sample
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from plotly_resampler import FigureResampler, FigureWidgetResampler
 
+from plotly_resampler import FigureResampler, FigureWidgetResampler
 
 # ----------------------- Figure as Base -----------------------
 if True:

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -3,20 +3,19 @@
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
 
-import pytest
-import time
 import datetime
 import multiprocessing
+import time
+from typing import List
 
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-
-from selenium.webdriver.common.by import By
-from typing import List
-
+import pytest
 from plotly.subplots import make_subplots
-from plotly_resampler import FigureResampler, LTTB, EveryNthPoint
+from selenium.webdriver.common.by import By
+
+from plotly_resampler import LTTB, EveryNthPoint, FigureResampler
 
 # Note: this will be used to skip / alter behavior when running browser tests on
 # non-linux platforms.
@@ -380,6 +379,7 @@ def test_nan_removed_input(float_series):
         col=2,
     )
 
+
 def test_nan_removed_input_check_nans_false(float_series):
     # see: https://plotly.com/python/subplots/#custom-sized-subplot-with-subplot-titles
     base_fig = make_subplots(
@@ -405,7 +405,7 @@ def test_nan_removed_input_check_nans_false(float_series):
         col=1,
         hf_text="text",
         hf_hovertext="hovertext",
-        check_nans=False
+        check_nans=False,
     )
     # Check the undesired behavior
     assert len(fig.hf_data[0]["y"]) == len(float_series)
@@ -904,10 +904,11 @@ def test_manual_jupyterdashpersistentinline():
 
     # no need to start the app (we just need the FigureResampler object)
 
+    import dash
+
     from plotly_resampler.figure_resampler.figure_resampler import (
         JupyterDashPersistentInlineOutput,
     )
-    import dash
 
     app = JupyterDashPersistentInlineOutput("manual_app")
     assert hasattr(app, "_uid")
@@ -923,9 +924,9 @@ def test_manual_jupyterdashpersistentinline():
     )
 
     # call the method (as it would normally be called)
-    app._display_in_jupyter(f"", port="", mode="inline", width="100%", height=500)
+    app._display_in_jupyter("", port="", mode="inline", width="100%", height=500)
     # call with a different mode (as it normally never would be called)
-    app._display_in_jupyter(f"", port="", mode="external", width="100%", height=500)
+    app._display_in_jupyter("", port="", mode="external", width="100%", height=500)
 
 
 def test_stop_server_external():
@@ -1292,33 +1293,33 @@ def test_fr_update_layout_axes_range(driver):
 
     # The xaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.xaxis.range == None
-    assert f_pr.layout.xaxis.range == None
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.range is None
+    assert f_pr.layout.xaxis.range is None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     f_orig.update_layout(xaxis_range=[100, 1000])
     f_pr.update_layout(xaxis_range=[100, 1000])
 
     assert f_orig.layout.xaxis.range == (100, 1000)
     assert f_pr.layout.xaxis.range == (100, 1000)
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     # The yaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.yaxis.range == None
-    assert f_pr.layout.yaxis.range == None
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.range is None
+    assert f_pr.layout.yaxis.range is None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     f_orig.update_layout(yaxis_range=[100, 1000])
     f_pr.update_layout(yaxis_range=[100, 1000])
 
     assert list(f_orig.layout.yaxis.range) == [100, 1000]
     assert list(f_pr.layout.yaxis.range) == [100, 1000]
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     # Before showing the figure, the f_pr contains the full original data (downsampled to 500 samples)
     # Even after updating the axes ranges
@@ -1333,7 +1334,7 @@ def test_fr_update_layout_axes_range(driver):
     proc.start()
     try:
         time.sleep(1)
-        driver.get(f"http://localhost:8050")
+        driver.get("http://localhost:8050")
         time.sleep(3)
         # Get the data property from the front-end figure
         el = driver.find_element(by=By.ID, value="resample-figure")
@@ -1380,33 +1381,33 @@ def test_fr_update_layout_axes_range_no_update(driver):
 
     # The xaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.xaxis.range == None
-    assert f_pr.layout.xaxis.range == None
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.range is None
+    assert f_pr.layout.xaxis.range is None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     f_orig.update_layout(xaxis_range=[100, 1000])
     f_pr.update_layout(xaxis_range=[100, 1000])
 
     assert f_orig.layout.xaxis.range == (100, 1000)
     assert f_pr.layout.xaxis.range == (100, 1000)
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     # The yaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.yaxis.range == None
-    assert f_pr.layout.yaxis.range == None
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.range is None
+    assert f_pr.layout.yaxis.range is None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     f_orig.update_layout(yaxis_range=[100, 1000])
     f_pr.update_layout(yaxis_range=[100, 1000])
 
     assert list(f_orig.layout.yaxis.range) == [100, 1000]
     assert list(f_pr.layout.yaxis.range) == [100, 1000]
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     # Before showing the figure, the f_pr contains the full original data (not downsampled)
     # Even after updating the axes ranges
@@ -1421,7 +1422,7 @@ def test_fr_update_layout_axes_range_no_update(driver):
     proc.start()
     try:
         time.sleep(1)
-        driver.get(f"http://localhost:8050")
+        driver.get("http://localhost:8050")
         time.sleep(3)
         # Get the data & layout property from the front-end figure
         el = driver.find_element(by=By.ID, value="resample-figure")

--- a/tests/test_figure_resampler_selenium.py
+++ b/tests/test_figure_resampler_selenium.py
@@ -549,7 +549,7 @@ def test_shared_hover_gui(driver, shared_hover_figure):
 
         fr.drag_and_zoom("x3y2", x0=0.1, x1=0.5, y0=0.5, y1=0.5)
 
-       # First, apply some horizontal based zooms
+        # First, apply some horizontal based zooms
         fr.clear_requests(sleep_time_s=1)
         fr.drag_and_zoom("x3y3", x0=0.1, x1=0.5, y0=0.5, y1=0.5)
         time.sleep(1)
@@ -628,7 +628,7 @@ def test_multi_trace_go_figure(driver, multi_trace_go_figure):
         fr.drag_and_zoom("xy", x0=0.1, x1=0.3, y0=0.6, y1=0.9)
         fr.clear_requests(sleep_time_s=3)
 
-       # First, apply some horizontal based zooms
+        # First, apply some horizontal based zooms
         fr.clear_requests(sleep_time_s=1)
         fr.drag_and_zoom("xy", x0=0.1, x1=0.2, y0=0.5, y1=0.5)
         time.sleep(3)

--- a/tests/test_figurewidget_resampler.py
+++ b/tests/test_figurewidget_resampler.py
@@ -3,16 +3,16 @@
 __author__ = "Jonas Van Der Donckt, Jeroen Van Der Donckt, Emiel Deprost"
 
 
-import pytest
 import datetime
-import numpy as np
-import pandas as pd
-import plotly.graph_objects as go
-
 from copy import copy
 from typing import List
 
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
 from plotly.subplots import make_subplots
+
 from plotly_resampler import EfficientLTTB, EveryNthPoint, FigureWidgetResampler
 
 
@@ -322,7 +322,7 @@ def test_nan_removed_input_check_nans_false(float_series):
         col=1,
         hf_text="text",
         hf_hovertext="hovertext",
-        check_nans=False
+        check_nans=False,
     )
     # Check the undesired behavior
     assert len(fig.hf_data[0]["y"]) == len(float_series)
@@ -463,9 +463,9 @@ def test_multiple_timezones():
 def test_multiple_timezones_in_single_x_index__datetimes_and_timestamps():
     # TODO: can be improved with pytest parametrize
     y = np.arange(20)
-    
-    index1 = pd.date_range('2018-01-01', periods=10, freq='H', tz="US/Eastern")
-    index2 = pd.date_range('2018-01-02', periods=10, freq='H', tz="Asia/Dubai")
+
+    index1 = pd.date_range("2018-01-01", periods=10, freq="H", tz="US/Eastern")
+    index2 = pd.date_range("2018-01-02", periods=10, freq="H", tz="Asia/Dubai")
     index_timestamps = index1.append(index2)
     assert all(isinstance(x, pd.Timestamp) for x in index_timestamps)
     index_datetimes = pd.Index([x.to_pydatetime() for x in index_timestamps])
@@ -500,7 +500,9 @@ def test_multiple_timezones_in_single_x_index__datetimes_and_timestamps():
         # Add as hf_x as object array of strings
         fr_fig = FigureWidgetResampler(default_n_shown_samples=10)
         with pytest.raises(ValueError):
-            fr_fig.add_trace(go.Scattergl(), hf_x=index.astype(str).astype("object"), hf_y=y)
+            fr_fig.add_trace(
+                go.Scattergl(), hf_x=index.astype(str).astype("object"), hf_y=y
+            )
 
         fig = go.Figure()
         fig.add_trace(go.Scattergl(x=index.astype("object"), y=y))
@@ -623,7 +625,7 @@ def test_hf_x_object_array():
     assert np.issubdtype(fig.hf_data[0]["x"].dtype, np.integer)
 
     ## Object array of strings
-    x = np.array(["x", "y"]*50).astype("object")
+    x = np.array(["x", "y"] * 50).astype("object")
     assert x.dtype == "object"
     # Add in the scatter
     with pytest.raises(ValueError):
@@ -935,11 +937,11 @@ def test_hf_data_subplots_non_shared_xaxes():
         },
         overwrite=False,
     )
-    x_0 = fwr.data[0]['x']
-    assert 0 <= x_0[0] <= (n / 1000)  
+    x_0 = fwr.data[0]["x"]
+    assert 0 <= x_0[0] <= (n / 1000)
     assert (n - 1000) <= x_0[-1] <= n - 1
-    x_1 = fwr.data[1]['x']
-    assert 40_000 <= x_1[0] <= 40_000 + (20_000 / 1000)  
+    x_1 = fwr.data[1]["x"]
+    assert 40_000 <= x_1[0] <= 40_000 + (20_000 / 1000)
     assert (60_000 - 20_000 / 1_000) <= x_1[-1] <= 60_000
 
 
@@ -960,11 +962,11 @@ def test_hf_data_subplots_non_shared_xaxes_row_col_none():
         },
         overwrite=False,
     )
-    x_0 = fwr.data[0]['x']
-    assert 0 <= x_0[0] <= (n / 1000)  
+    x_0 = fwr.data[0]["x"]
+    assert 0 <= x_0[0] <= (n / 1000)
     assert (n - 1000) <= x_0[-1] <= n - 1
-    x_1 = fwr.data[1]['x']
-    assert 40_000 <= x_1[0] <= 40_000 + (20_000 / 1000)  
+    x_1 = fwr.data[1]["x"]
+    assert 40_000 <= x_1[0] <= 40_000 + (20_000 / 1000)
     assert (60_000 - 20_000 / 1_000) <= x_1[-1] <= 60_000
 
 
@@ -1113,7 +1115,7 @@ def test_updates_two_traces_single_trace_adjust():
 
     # check whether the single traces was updated with the showspike method
     assert ["showspikes-update", 1] in fw_fig._relayout_hist
-    assert not ["showspikes-update", 2] in fw_fig._relayout_hist
+    assert ["showspikes-update", 2] not in fw_fig._relayout_hist
     assert sum([["showspikes-update", 1] == rh for rh in fw_fig._relayout_hist]) == 1
     # check whether the xaxis-range-update was did not enter the update state
     assert (
@@ -1287,14 +1289,14 @@ def test_bare_update_methods():
 
     # perform an reset axis
     fw_fig._relayout_hist.clear()
-    l = fw_fig.layout.update(
+    layout = fw_fig.layout.update(
         {
             "xaxis": {"autorange": True, "showspikes": False},
             "xaxis2": {"autorange": True, "showspikes": False},
         },
         overwrite=True,  # by setting this to true -> the update call will not takte clear
     )
-    fw_fig._update_spike_ranges(l, False, False)
+    fw_fig._update_spike_ranges(layout, False, False)
 
     # Assert that only a single trace was updated
     assert ["showspikes-update", 1] in fw_fig._relayout_hist
@@ -1358,12 +1360,12 @@ def test_fwr_update_trace_data_zoom():
     )
 
     # zoom in on the first row it's xaxis and perform a layout update
-    l = fig.layout.update(
+    layout = fig.layout.update(
         {"xaxis": {"range": [0, 100_000]}},
         overwrite=True,
     )
     fig._update_x_ranges(
-        l, (0, 100_000), (fig.hf_data[1]["x"][0], fig.hf_data[1]["x"][-1])
+        layout, (0, 100_000), (fig.hf_data[1]["x"][0], fig.hf_data[1]["x"][-1])
     )
 
     fig._relayout_hist.clear()
@@ -1390,11 +1392,11 @@ def test_fwr_update_trace_data_zoom():
     )
 
     # zoom in on the second row it's xaxis and perform a layout update
-    l = fig.layout.update(
+    layout = fig.layout.update(
         {"xaxis2": {"range": [200_000, 500_000]}},
         overwrite=True,
     )
-    fig._update_x_ranges(l, (0, 100_000), (200_000, 500_000))
+    fig._update_x_ranges(layout, (0, 100_000), (200_000, 500_000))
 
     fig._relayout_hist.clear()
     fig.hf_data[0]["x"] = fig.hf_data[0]["x"]
@@ -1524,21 +1526,6 @@ def test_fwr_hovertext_adjust_unequal_length():
         fig.reload_data()
 
 
-def test_fwr_hovertext_adjust_unequal_length():
-    k = 10_000
-    fig = FigureWidgetResampler(default_n_shown_samples=1000, verbose=True)
-    fig.add_trace(go.Scattergl(name="A", line_color="red"), limit_to_view=True)
-
-    fig._relayout_hist.clear()
-
-    with pytest.raises(ValueError):
-        A = np.random.randn(k)
-        fig.hf_data[0]["x"] = pd.Series(np.arange(k - 500))
-        fig.hf_data[0]["y"] = np.arange(k - 500) + A * 300 * 20
-        fig.hf_data[0]["hovertext"] = (-A * 20).astype(int).astype(str)
-        fig.reload_data()
-
-
 def test_fwr_adjust_series_input():
     k = 10_000
     a_k = np.arange(k)
@@ -1613,7 +1600,9 @@ def test_fwr_time_based_data_ns():
     for i in range(3):
         s = pd.Series(
             index=pd.date_range(
-                datetime.datetime.now(), freq=f"{np.random.randint(5,100_000)}ns", periods=n
+                datetime.datetime.now(),
+                freq=f"{np.random.randint(5,100_000)}ns",
+                periods=n,
             ),
             data=np.arange(n),
         )
@@ -1651,7 +1640,9 @@ def test_fwr_time_based_data_us():
     for i in range(3):
         s = pd.Series(
             index=pd.date_range(
-                datetime.datetime.now(), freq=f"{np.random.randint(5,100_000)}us", periods=n
+                datetime.datetime.now(),
+                freq=f"{np.random.randint(5,100_000)}us",
+                periods=n,
             ),
             data=np.arange(n),
         )
@@ -1689,7 +1680,9 @@ def test_fwr_time_based_data_ms():
     for i in range(3):
         s = pd.Series(
             index=pd.date_range(
-                datetime.datetime.now(), freq=f"{np.random.randint(5,10_000)}ms", periods=n
+                datetime.datetime.now(),
+                freq=f"{np.random.randint(5,10_000)}ms",
+                periods=n,
             ),
             data=np.arange(n),
         )
@@ -2019,7 +2012,9 @@ def test_fwr_object_bool_data(bool_series):
 
 
 def test_fwr_object_binary_data():
-    binary_series = np.array([0, 1]*20, dtype="int32")  # as this is << max_n_samples -> limit_to_view
+    binary_series = np.array(
+        [0, 1] * 20, dtype="int32"
+    )  # as this is << max_n_samples -> limit_to_view
 
     # First try with the original non-object binary series
     fig = FigureWidgetResampler()
@@ -2036,7 +2031,9 @@ def test_fwr_object_binary_data():
     fig.add_trace({"name": "s0"}, hf_y=binary_series_o, limit_to_view=True)
     assert binary_series_o.dtype == object
     assert len(fig.hf_data) == 1
-    assert (fig.hf_data[0]["y"].dtype == "int32") or (fig.hf_data[0]["y"].dtype == "int64")
+    assert (fig.hf_data[0]["y"].dtype == "int32") or (
+        fig.hf_data[0]["y"].dtype == "int64"
+    )
     assert str(fig.data[0]["y"].dtype).startswith("int")
     assert np.all(fig.data[0]["y"] == binary_series)
 
@@ -2051,7 +2048,7 @@ def test_fwr_update_layout_axes_range():
         y=np.arange(nb_datapoints)
     )
 
-    def check_data(fwr: FigureWidgetResampler, min_v=0, max_v=nb_datapoints-1):
+    def check_data(fwr: FigureWidgetResampler, min_v=0, max_v=nb_datapoints - 1):
         # closure for n_shown and nb_datapoints
         assert len(fwr.data[0]["y"]) == min(n_shown, nb_datapoints)
         assert len(fwr.data[0]["x"]) == min(n_shown, nb_datapoints)
@@ -2065,37 +2062,37 @@ def test_fwr_update_layout_axes_range():
 
     # The xaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.xaxis.range == None
-    assert f_pr.layout.xaxis.range == None
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.range is None
+    assert f_pr.layout.xaxis.range is None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     f_orig.update_layout(xaxis_range=[100, 1000])
     f_pr.update_layout(xaxis_range=[100, 1000])
 
     assert f_orig.layout.xaxis.range == (100, 1000)
     assert f_pr.layout.xaxis.range == (100, 1000)
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     # The yaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.yaxis.range == None
-    assert f_pr.layout.yaxis.range == None
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.range is None
+    assert f_pr.layout.yaxis.range is None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     f_orig.update_layout(yaxis_range=[100, 1000])
     f_pr.update_layout(yaxis_range=[100, 1000])
 
     assert list(f_orig.layout.yaxis.range) == [100, 1000]
     assert list(f_pr.layout.yaxis.range) == [100, 1000]
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     # Now the f_pr contains the data of the selected xrange (downsampled to 500 samples)
-    check_data(f_pr, 100, 1_000-1)
-    
+    check_data(f_pr, 100, 1_000 - 1)
+
 
 def test_fwr_update_layout_axes_range_no_update():
     nb_datapoints = 2_000
@@ -2107,7 +2104,7 @@ def test_fwr_update_layout_axes_range_no_update():
         y=np.arange(nb_datapoints)
     )
 
-    def check_data(fwr: FigureWidgetResampler, min_v=0, max_v=nb_datapoints-1):
+    def check_data(fwr: FigureWidgetResampler, min_v=0, max_v=nb_datapoints - 1):
         # closure for n_shown and nb_datapoints
         assert len(fwr.data[0]["y"]) == min(n_shown, nb_datapoints)
         assert len(fwr.data[0]["x"]) == min(n_shown, nb_datapoints)
@@ -2121,33 +2118,33 @@ def test_fwr_update_layout_axes_range_no_update():
 
     # The xaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.xaxis.range == None
-    assert f_pr.layout.xaxis.range == None
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.range is None
+    assert f_pr.layout.xaxis.range is None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     f_orig.update_layout(xaxis_range=[100, 1000])
     f_pr.update_layout(xaxis_range=[100, 1000])
 
     assert f_orig.layout.xaxis.range == (100, 1000)
     assert f_pr.layout.xaxis.range == (100, 1000)
-    assert f_orig.layout.xaxis.autorange == None
-    assert f_pr.layout.xaxis.autorange == None
+    assert f_orig.layout.xaxis.autorange is None
+    assert f_pr.layout.xaxis.autorange is None
 
     # The yaxis (auto)range should be the same for both figures
 
-    assert f_orig.layout.yaxis.range == None
-    assert f_pr.layout.yaxis.range == None
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.range is None
+    assert f_pr.layout.yaxis.range is None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     f_orig.update_layout(yaxis_range=[100, 1000])
     f_pr.update_layout(yaxis_range=[100, 1000])
 
     assert list(f_orig.layout.yaxis.range) == [100, 1000]
     assert list(f_pr.layout.yaxis.range) == [100, 1000]
-    assert f_orig.layout.yaxis.autorange == None
-    assert f_pr.layout.yaxis.autorange == None
+    assert f_orig.layout.yaxis.autorange is None
+    assert f_pr.layout.yaxis.autorange is None
 
     # Now the f_pr still contains the full original data (not downsampled)
     # Even after updating the axes ranges
@@ -2170,7 +2167,7 @@ def test_fwr_copy_grid():
     assert fwr._grid_ref == f._grid_ref
     assert fwr._grid_str is not None
     assert fwr._grid_str == f._grid_str
-    
+
     ## go.FigureWidget
     fw = go.FigureWidget(f)
     assert fw._grid_ref is not None
@@ -2195,6 +2192,7 @@ def test_fwr_copy_grid():
 
     ## FigureResampler
     from plotly_resampler import FigureResampler
+
     fr = FigureResampler(f)
     assert fr._grid_ref is not None
     assert fr._grid_str is not None

--- a/tests/test_registering.py
+++ b/tests/test_registering.py
@@ -1,19 +1,20 @@
-import plotly.graph_objects as go
-import plotly.express as px
+from inspect import isfunction
+
 import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
 
 from plotly_resampler import FigureResampler, FigureWidgetResampler
 from plotly_resampler.figure_resampler.figure_resampler_interface import (
     AbstractFigureAggregator,
 )
 from plotly_resampler.registering import (
+    _get_plotly_constr,
     register_plotly_resampler,
     unregister_plotly_resampler,
-    _get_plotly_constr,
 )
 
 from .conftest import registering_cleanup
-from inspect import isfunction
 
 
 def test_get_plotly_const(registering_cleanup):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,25 +1,22 @@
-from hashlib import sha1
-import plotly.graph_objects as go
-import plotly.express as px
-import numpy as np
-import pickle
 import copy
+import pickle
 
+import numpy as np
+import plotly.graph_objects as go
 from plotly.subplots import make_subplots
+
 from plotly_resampler import FigureResampler, FigureWidgetResampler
 from plotly_resampler.registering import (
     register_plotly_resampler,
     unregister_plotly_resampler,
-    _get_plotly_constr,
 )
 
-from .conftest import registering_cleanup, pickle_figure
-from inspect import isfunction
-
+from .conftest import pickle_figure, registering_cleanup
 
 #### PICKLING
 
 ## Test basic pickling
+
 
 def test_pickle_figure_resampler(pickle_figure):
     nb_traces = 3
@@ -49,18 +46,21 @@ def test_pickle_figure_resampler(pickle_figure):
     # Test for figure with subplots (check non-pickled private properties)
     fig = FigureResampler(
         make_subplots(rows=2, cols=1, shared_xaxes=True),
-        default_n_shown_samples=50, show_dash_kwargs=dict(port=8051),
+        default_n_shown_samples=50,
+        show_dash_kwargs=dict(port=8051),
     )
     for i in range(nb_traces):
         fig.add_trace(
-            go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples),
-            row=(i % 2) + 1, col=1,
+            go.Scattergl(name=f"trace--{i}"),
+            hf_y=np.arange(nb_samples),
+            row=(i % 2) + 1,
+            col=1,
         )
     assert fig._global_n_shown_samples == 50
     assert fig._show_dash_kwargs["port"] == 8051
     assert fig._figure_class == go.Figure
-    assert fig._xaxis_list == ['xaxis', 'xaxis2']
-    assert fig._yaxis_list == ['yaxis', 'yaxis2']
+    assert fig._xaxis_list == ["xaxis", "xaxis2"]
+    assert fig._yaxis_list == ["yaxis", "yaxis2"]
 
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
@@ -69,8 +69,8 @@ def test_pickle_figure_resampler(pickle_figure):
     assert fig_pickle._global_n_shown_samples == 50
     assert fig_pickle._show_dash_kwargs["port"] == 8051
     assert fig_pickle._figure_class == go.Figure
-    assert fig_pickle._xaxis_list == ['xaxis', 'xaxis2']
-    assert fig_pickle._yaxis_list == ['yaxis', 'yaxis2']
+    assert fig_pickle._xaxis_list == ["xaxis", "xaxis2"]
+    assert fig_pickle._yaxis_list == ["yaxis", "yaxis2"]
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -113,13 +113,15 @@ def test_pickle_figurewidget_resampler(pickle_figure):
     )
     for i in range(nb_traces):
         fig.add_trace(
-            go.Scattergl(name=f"trace--{i}"), hf_y=np.arange(nb_samples),
-            row=(i % 2) + 1, col=1,
+            go.Scattergl(name=f"trace--{i}"),
+            hf_y=np.arange(nb_samples),
+            row=(i % 2) + 1,
+            col=1,
         )
     assert fig._global_n_shown_samples == 50
     assert fig._figure_class == go.FigureWidget
-    assert fig._xaxis_list == ['xaxis', 'xaxis2']
-    assert fig._yaxis_list == ['yaxis', 'yaxis2']
+    assert fig._xaxis_list == ["xaxis", "xaxis2"]
+    assert fig._yaxis_list == ["yaxis", "yaxis2"]
 
     pickle.dump(fig, open(pickle_figure, "wb"))
     fig_pickle = pickle.load(open(pickle_figure, "rb"))
@@ -127,8 +129,8 @@ def test_pickle_figurewidget_resampler(pickle_figure):
     assert isinstance(fig_pickle, FigureWidgetResampler)
     assert fig_pickle._global_n_shown_samples == 50
     assert fig_pickle._figure_class == go.FigureWidget
-    assert fig_pickle._xaxis_list == ['xaxis', 'xaxis2']
-    assert fig_pickle._yaxis_list == ['yaxis', 'yaxis2']
+    assert fig_pickle._xaxis_list == ["xaxis", "xaxis2"]
+    assert fig_pickle._yaxis_list == ["yaxis", "yaxis2"]
     assert len(fig_pickle.data) == nb_traces
     assert len(fig_pickle.hf_data) == nb_traces
     for i in range(nb_traces):
@@ -142,6 +144,7 @@ def test_pickle_figurewidget_resampler(pickle_figure):
 
 
 ## Test pickling when registered
+
 
 def test_pickle_figure_resampler_registered(registering_cleanup, pickle_figure):
     nb_traces = 4
@@ -316,6 +319,7 @@ def test_pickle_figurewidget_resampler_registered(registering_cleanup, pickle_fi
 
 ## Test basic (deep)copy
 
+
 def test_copy_and_deepcopy_figure_resampler():
     nb_traces = 3
     nb_samples = 3_243
@@ -394,6 +398,7 @@ def test_copy_and_deepcopy_figurewidget_resampler():
 
 
 ## Test basic (deep)copy with PR registered
+
 
 def test_copy_figure_resampler_registered():
     nb_traces = 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,16 @@
 import pandas as pd
 import plotly.graph_objects as go
+
+from plotly_resampler import FigureResampler, FigureWidgetResampler
 from plotly_resampler.figure_resampler.utils import (
     is_figure,
     is_figurewidget,
     is_fr,
     is_fwr,
-    timedelta_to_str,
-    round_td_str,
     round_number_str,
+    round_td_str,
+    timedelta_to_str,
 )
-from plotly_resampler import FigureResampler, FigureWidgetResampler
 
 
 def test_is_figure():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,9 @@
 import sys
 
+
 def not_on_linux():
     """Return True if the current platform is not Linux.
-    
+
     This is to avoid / alter test bahavior for non-Linux (as browser testing gets
     tricky on other platforms).
     """


### PR DESCRIPTION
This PR adds the following CI-CD checks:
- [x] linting with ruff
- [x] formatting with black (line-length = 88)
- [x] sorting imports with isort

:robot: added a `Makefile` to, uhm, *make* it more convenient to call the lint & formatting commands
* Formatting the code: `make lint`
* Linting the code: `make lint`