### PR TITLE
:bug: return None when rounding 0

### DIFF
--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -114,6 +114,7 @@ def timedelta_to_str(td: pd.Timedelta) -> str:
     -------
     str:
         The tight string bounds of format '$d-$h$m$s.$ms'.
+        If the timedelta is negative, the string starts with 'NEG'.
 
     """
     out_str = ""
@@ -153,8 +154,20 @@ def timedelta_to_str(td: pd.Timedelta) -> str:
 def round_td_str(td: pd.Timedelta) -> str:
     """Round a timedelta to the nearest unit and convert to a string.
 
+    Parameters
+    ----------
+    td : pd.Timedelta
+        The timedelta to round.
+
+    Returns
+    -------
+    str
+        The rounded timedelta as a string.
+        If the timedelta is == 0, None is returned.
+
     .. seealso::
         :func:`timedelta_to_str`
+
     """
     for t_s in ("D", "H", "min", "s", "ms", "us", "ns"):
         if td > 0.95 * pd.Timedelta(f"1{t_s}"):
@@ -162,10 +175,25 @@ def round_td_str(td: pd.Timedelta) -> str:
 
 
 def round_number_str(number: float) -> str:
+    """Round a number to the nearest unit and convert to a string.
+
+    Parameters
+    ----------
+    number : float
+        The number to round.
+
+    Returns
+    -------
+    str
+        The rounded number as a string.
+        If the number is <= 0, None is returned.
+
+    """
     if number > 0.95:
         for unit, scaling in (("M", int(1e6)), ("k", int(1e3))):
             if number / scaling > 0.95:
                 return f"{round(number / scaling)}{unit}"
         return str(round(number))
-    # we have a number < 1 --> round till nearest non-zero digit
-    return str(round(number, 1 + abs(int(math.log10(number)))))
+    if number > 0:  # avoid log10(0)
+        # we have a number between 0-0.95 -> round till nearest non-zero digit
+        return str(round(number, 1 + abs(int(math.log10(number)))))

--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -186,14 +186,16 @@ def round_number_str(number: float) -> str:
     -------
     str
         The rounded number as a string.
-        If the number is <= 0, None is returned.
+        If the number is == 0, None is returned.
 
     """
+    sign = "-" if number < 0 else ""
+    number = abs(number)
     if number > 0.95:
         for unit, scaling in (("M", int(1e6)), ("k", int(1e3))):
             if number / scaling > 0.95:
                 return f"{round(number / scaling)}{unit}"
-        return str(round(number))
+        return sign + str(round(number))
     if number > 0:  # avoid log10(0)
         # we have a number between 0-0.95 -> round till nearest non-zero digit
-        return str(round(number, 1 + abs(int(math.log10(number)))))
+        return sign + str(round(number, 1 + abs(int(math.log10(number)))))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,7 @@ def test_timedelta_to_str():
     assert round_td_str(pd.Timedelta("1128.9us")) == "1ms"
     assert round_td_str(pd.Timedelta("128.9us")) == "129us"
     assert round_td_str((pd.Timedelta("14ns"))) == "14ns"
-    assert round_td_str((pd.Timedelta("0ns"))) == None
+    assert round_td_str((pd.Timedelta("0ns"))) is None
 
 
 def test_round_int_str():
@@ -110,4 +110,4 @@ def test_round_int_str():
     assert round_number_str(950_001) == "1M"
     assert round_number_str(1_950_001) == "2M"
     assert round_number_str(111_950_001) == "112M"
-    assert round_number_str(0) == None
+    assert round_number_str(0) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,7 @@ def test_timedelta_to_str():
     assert round_td_str(pd.Timedelta("1128.9us")) == "1ms"
     assert round_td_str(pd.Timedelta("128.9us")) == "129us"
     assert round_td_str((pd.Timedelta("14ns"))) == "14ns"
+    assert round_td_str((pd.Timedelta("0ns"))) == None
 
 
 def test_round_int_str():
@@ -109,3 +110,4 @@ def test_round_int_str():
     assert round_number_str(950_001) == "1M"
     assert round_number_str(1_950_001) == "2M"
     assert round_number_str(111_950_001) == "112M"
+    assert round_number_str(0) == None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,7 @@ def test_timedelta_to_str():
     assert round_td_str(pd.Timedelta("1128.9us")) == "1ms"
     assert round_td_str(pd.Timedelta("128.9us")) == "129us"
     assert round_td_str((pd.Timedelta("14ns"))) == "14ns"
+    # zero should return None
     assert round_td_str((pd.Timedelta("0ns"))) is None
 
 
@@ -110,4 +111,8 @@ def test_round_int_str():
     assert round_number_str(950_001) == "1M"
     assert round_number_str(1_950_001) == "2M"
     assert round_number_str(111_950_001) == "112M"
+    # zero should return None
     assert round_number_str(0) is None
+    # negative case
+    assert round_number_str(-0.951) == "-1"
+    assert round_number_str(-0.95) == "-0.9"


### PR DESCRIPTION
Fixes #171 

When rounding numbers or timedelta's, None is returned when the number (i.e., diff) == 0

- [x] update code to make timedelta & float rounding return None when rounding 0
- [x] update docs
- [x] update tests 