### PR TITLE
Rework aggregator interface 

### DIFF
--- a/plotly_resampler/aggregation/aggregation_interface.py
+++ b/plotly_resampler/aggregation/aggregation_interface.py
@@ -1,5 +1,7 @@
 """AbstractSeriesAggregator interface-class, subclassed by concrete aggregators."""
 
+from __future__ import annotations
+
 __author__ = "Jonas Van Der Donckt"
 
 import re
@@ -79,7 +81,7 @@ class AbstractAggregator(ABC):
         A gap is *currently* defined as a difference between two consecutive x values,
         that is larger than 4 times the median difference between two consecutive x
         values.
-        Note: this is a very naive approach, but it seems to work well.
+        Note: this is a naive approach, but it seems to work well.
 
         Parameters
         ----------
@@ -170,10 +172,11 @@ class AbstractAggregator(ABC):
         If only y is passed, x is set to None.
         """
         assert len(args) in [1, 2], "Must pass either 1 or 2 arrays"
-        if len(args) == 1:
-            # only y is passed
-            return None, args[0]
-        return args  # x, y
+        x, y = (None, args[0]) if len(args) == 1 else args
+        if hasattr(y, "values"):
+            y = y.values
+        # TODO -> what to do with the x index?
+        return x, y
 
     @staticmethod
     def _check_arr(arr: np.ndarray, regex_list: Optional[List[str]] = None):

--- a/plotly_resampler/aggregation/aggregation_interface.py
+++ b/plotly_resampler/aggregation/aggregation_interface.py
@@ -173,9 +173,6 @@ class AbstractAggregator(ABC):
         """
         assert len(args) in [1, 2], "Must pass either 1 or 2 arrays"
         x, y = (None, args[0]) if len(args) == 1 else args
-        if hasattr(y, "values"):
-            y = y.values
-        # TODO -> what to do with the x index?
         return x, y
 
     @staticmethod

--- a/plotly_resampler/aggregation/aggregation_interface.py
+++ b/plotly_resampler/aggregation/aggregation_interface.py
@@ -214,6 +214,7 @@ class DataAggregator(AbstractAggregator, ABC):
 
         Parameters
         ----------
+        x, y: np.ndarray
             The x and y data of the to-be-aggregated series.
             The x array is optional (i.e., if only 1 array is passed, it is assumed to
             be the y array).

--- a/plotly_resampler/aggregation/aggregators.py
+++ b/plotly_resampler/aggregation/aggregators.py
@@ -7,10 +7,13 @@
 
 """
 
+from __future__ import annotations
+
 __author__ = "Jonas Van Der Donckt"
 
+
 import math
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 
@@ -333,7 +336,6 @@ class FuncAggregator(DataAggregator):
         n_out: int,
         **kwargs,
     ) -> Tuple[np.ndarray, np.ndarray]:
-
         # Create an index-estimation for real-time data
         # Add one to the index so it's pointed at the end of the window
         # Note: this can be adjusted to .5 to center the data

--- a/plotly_resampler/aggregation/aggregators.py
+++ b/plotly_resampler/aggregation/aggregators.py
@@ -13,7 +13,6 @@ import math
 from typing import Optional, Tuple
 
 import numpy as np
-import pandas as pd
 
 from ..aggregation.aggregation_interface import DataAggregator, DataPointSelector
 
@@ -75,9 +74,9 @@ class LTTB(DataPointSelector):
 
     def _arg_downsample(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **_,
     ) -> np.ndarray:
         # Use the Core interface to perform the downsampling
@@ -116,9 +115,9 @@ class MinMaxOverlapAggregator(DataPointSelector):
 
     def _arg_downsample(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> np.ndarray:
         # The block size 2x the bin size we also perform the ceil-operation
@@ -176,9 +175,9 @@ class MinMaxAggregator(DataPointSelector):
 
     def _arg_downsample(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> np.ndarray:
         # The block size 2x the bin size we also perform the ceil-operation
@@ -244,9 +243,9 @@ class MinMaxLTTB(DataPointSelector):
 
     def _arg_downsample(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> np.ndarray:
         size_threshold = 10_000_000
@@ -283,9 +282,9 @@ class EveryNthPoint(DataPointSelector):
 
     def _arg_downsample(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> np.ndarray:
         # TODO: check the "-1" below
@@ -329,9 +328,9 @@ class FuncAggregator(DataAggregator):
 
     def _aggregate(
         self,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        n_out: int = None,
+        x: np.ndarray | None,
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> Tuple[np.ndarray, np.ndarray]:
 
@@ -346,8 +345,9 @@ class FuncAggregator(DataAggregator):
             idxs = (np.arange(n_out) * group_size).astype(int)
         else:
             x_ = x
-            # TODO: perhaps we can make pandas optional and import it here
-            if isinstance(x, (pd.DatetimeIndex, pd.TimedeltaIndex)):
+            if np.issubdtype(x.dtype, np.datetime64) or np.issubdtype(
+                x.dtype, np.timedelta64
+            ):
                 x_ = x_.view("int64")
             # Thanks to `linspace`, the data is evenly distributed over the index-range
             # The searchsorted function returns the index positions

--- a/plotly_resampler/aggregation/aggregators.py
+++ b/plotly_resampler/aggregation/aggregators.py
@@ -291,6 +291,7 @@ class EveryNthPoint(DataPointSelector):
         **kwargs,
     ) -> np.ndarray:
         # TODO: check the "-1" below
+        # TODO: add equidistant version using searchsorted on a linspace
         return np.arange(step=max(1, math.ceil(len(y) / n_out)), stop=len(y) - 1)
 
 
@@ -346,14 +347,12 @@ class FuncAggregator(DataAggregator):
             group_size = max(1, np.ceil(len(y) / n_out))
             idxs = (np.arange(n_out) * group_size).astype(int)
         else:
-            x_ = x
-            if np.issubdtype(x.dtype, np.datetime64) or np.issubdtype(
-                x.dtype, np.timedelta64
-            ):
-                x_ = x_.view("int64")
+            xdt = x.dtype
+            if np.issubdtype(xdt, np.datetime64) or np.issubdtype(xdt, np.timedelta64):
+                x = x.view("int64")
             # Thanks to `linspace`, the data is evenly distributed over the index-range
             # The searchsorted function returns the index positions
-            idxs = np.searchsorted(x_, np.linspace(x_[0], x_[-1], n_out + 1))
+            idxs = np.searchsorted(x, np.linspace(x[0], x[-1], n_out + 1))
 
         y_agg = np.array(
             [

--- a/plotly_resampler/aggregation/algorithms/lttb_c.py
+++ b/plotly_resampler/aggregation/algorithms/lttb_c.py
@@ -33,6 +33,10 @@ class LTTB_core_c:
         np.ndarray
             The indexes of the selected datapoints.
         """
+        xdt = x.dtype
+        if np.issubdtype(xdt, np.datetime64) or np.issubdtype(xdt, np.timedelta64):
+            x = x.view(np.int64)
+
         if x.dtype == np.int64 and y.dtype == np.float64:
             return downsample_int_double(x, y, n_out)
         elif x.dtype == y.dtype == np.int64:

--- a/plotly_resampler/aggregation/plotly_aggregator_parser.py
+++ b/plotly_resampler/aggregation/plotly_aggregator_parser.py
@@ -9,13 +9,17 @@ from .aggregation_interface import DataAggregator, DataPointSelector
 
 class PlotlyAggregatorParser:
     @staticmethod
-    def parse_hf_data(hf_data_dict, hf_keys: List[str]):
-        # TODO: check overhead --> add this to a hf_data parsing function
-        for k in hf_keys:
-            # if k in hf_data_dict and hasattr(hf_data_dict[k], "values"):
-            if k in hf_data_dict and hasattr(hf_data_dict[k], "to_numpy"):
-                # if k in hf_data_dict and isinstance(hf_data_dict[k], (pd.Series)):
-                hf_data_dict[k] = hf_data_dict[k].to_numpy()
+    def parse_hf_data(hf_data: np.ndarray | pd.Categorical | pd.Series | pd.Index):
+        """Parse the high-frequency data to a numpy array."""
+        # Categorical data (pandas)
+        #   - pd.Series with categorical dtype -> calling .values will returns a
+        #       pd.Categorical
+        #   - pd.CategoricalIndex -> calling .values returns a pd.Categorical
+        #   - pd.Categorical: has no .values attribute -> will not be parsed
+        if isinstance(hf_data, (pd.Series, pd.Index)):
+            # TODO: range index
+            return hf_data.values
+        return hf_data
 
     @staticmethod
     def to_same_tz(
@@ -92,16 +96,15 @@ class PlotlyAggregatorParser:
 
         downsampler = hf_trace_data["downsampler"]
 
+        hf_x_parsed = PlotlyAggregatorParser.parse_hf_data(hf_x)
+        hf_y_parsed = PlotlyAggregatorParser.parse_hf_data(hf_y)
+
         if isinstance(downsampler, DataPointSelector):
-            s_v = hf_y
-            if hasattr(hf_y, "values"):
-                # TODO: this line should not be needed here as we perform the
-                # parsing in the `parse_hf_data` function
-                s_v = hf_y.values
-            if str(s_v.dtype) == "category":
+            s_v = hf_y_parsed
+            if str(s_v.dtype) == "category":  # pd.Categorical (has no .values)
                 s_v = s_v.codes
             indices = downsampler.arg_downsample(
-                hf_x,
+                hf_x_parsed,
                 s_v,
                 n_out=hf_trace_data["max_n_samples"],
                 **hf_trace_data.get("downsampler_kwargs", {}),
@@ -118,8 +121,8 @@ class PlotlyAggregatorParser:
             agg_y = hf_y[indices]
         elif isinstance(downsampler, DataAggregator):
             agg_x, agg_y = downsampler.aggregate(
-                hf_x,
-                hf_y,
+                hf_x_parsed,
+                hf_y_parsed,
                 n_out=hf_trace_data["max_n_samples"],
                 **hf_trace_data.get("downsampler_kwargs", {}),
             )
@@ -145,13 +148,12 @@ class PlotlyAggregatorParser:
         # Interleave the gaps`
         # View the data as an int64 when we have a DatetimeIndex
         # We only want to detect gaps, so we only want to compare values.
-        agg_x_view = agg_x
-        if np.issubdtype(agg_x.dtype, np.timedelta64) or np.issubdtype(
-            agg_x.dtype, np.datetime64
-        ):
-            agg_x_view = agg_x.view("int64")
+        agg_x_parsed = PlotlyAggregatorParser.parse_hf_data(agg_x)
+        xdt = agg_x_parsed.dtype
+        if np.issubdtype(xdt, np.timedelta64) or np.issubdtype(xdt, np.datetime64):
+            agg_x_parsed = agg_x_parsed.view("int64")
 
-        agg_y, indices = downsampler.insert_none_at_gaps(agg_x_view, agg_y, indices)
+        agg_y, indices = downsampler.insert_none_at_gaps(agg_x_parsed, agg_y, indices)
         if isinstance(downsampler, DataPointSelector):
             agg_x = hf_x[indices]
         elif isinstance(downsampler, DataAggregator):

--- a/plotly_resampler/aggregation/plotly_aggregator_parser.py
+++ b/plotly_resampler/aggregation/plotly_aggregator_parser.py
@@ -12,9 +12,10 @@ class PlotlyAggregatorParser:
     def parse_hf_data(hf_data_dict, hf_keys: List[str]):
         # TODO: check overhead --> add this to a hf_data parsing function
         for k in hf_keys:
-            if k in hf_data_dict and isinstance(hf_data_dict[k], pd.Series):
-                # TODO: we can ommit pandas here, by using hasattr - see below
-                hf_data_dict[k] = hf_data_dict[k].values
+            # if k in hf_data_dict and hasattr(hf_data_dict[k], "values"):
+            if k in hf_data_dict and hasattr(hf_data_dict[k], "to_numpy"):
+                # if k in hf_data_dict and isinstance(hf_data_dict[k], (pd.Series)):
+                hf_data_dict[k] = hf_data_dict[k].to_numpy()
 
     @staticmethod
     def to_same_tz(
@@ -70,7 +71,7 @@ class PlotlyAggregatorParser:
 
     @staticmethod
     def aggregate(
-        hf_trace_data,
+        hf_trace_data: dict,
         start_idx: int,
         end_idx: int,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -102,7 +103,7 @@ class PlotlyAggregatorParser:
             indices = downsampler.arg_downsample(
                 hf_x,
                 s_v,
-                hf_trace_data["max_n_samples"],
+                n_out=hf_trace_data["max_n_samples"],
                 **hf_trace_data.get("downsampler_kwargs", {}),
             )
             # we avoid slicing the default pd.RangeIndex
@@ -119,7 +120,7 @@ class PlotlyAggregatorParser:
             agg_x, agg_y = downsampler.aggregate(
                 hf_x,
                 hf_y,
-                hf_trace_data["max_n_samples"],
+                n_out=hf_trace_data["max_n_samples"],
                 **hf_trace_data.get("downsampler_kwargs", {}),
             )
             # The indices are just the range of the aggregated data

--- a/plotly_resampler/aggregation/plotly_aggregator_parser.py
+++ b/plotly_resampler/aggregation/plotly_aggregator_parser.py
@@ -9,7 +9,9 @@ from .aggregation_interface import DataAggregator, DataPointSelector
 
 class PlotlyAggregatorParser:
     @staticmethod
-    def parse_hf_data(hf_data: np.ndarray | pd.Categorical | pd.Series | pd.Index):
+    def parse_hf_data(
+        hf_data: np.ndarray | pd.Categorical | pd.Series | pd.Index,
+    ) -> np.ndarray | pd.Categorical:
         """Parse the high-frequency data to a numpy array."""
         # Categorical data (pandas)
         #   - pd.Series with categorical dtype -> calling .values will returns a

--- a/plotly_resampler/aggregation/plotly_aggregator_parser.py
+++ b/plotly_resampler/aggregation/plotly_aggregator_parser.py
@@ -149,7 +149,7 @@ class PlotlyAggregatorParser:
         if isinstance(agg_x, (pd.DatetimeIndex, pd.TimedeltaIndex)):
             agg_x_view = agg_x.view("int64")
 
-        agg_y, indices = downsampler.insert_gap_none(agg_x_view, agg_y, indices)
+        agg_y, indices = downsampler.insert_none_at_gaps(agg_x_view, agg_y, indices)
         if isinstance(downsampler, DataPointSelector):
             agg_x = hf_x[indices]
         elif isinstance(downsampler, DataAggregator):

--- a/plotly_resampler/aggregation/plotly_aggregator_parser.py
+++ b/plotly_resampler/aggregation/plotly_aggregator_parser.py
@@ -94,7 +94,7 @@ class PlotlyAggregatorParser:
 
         if isinstance(downsampler, DataPointSelector):
             s_v = hf_y
-            if isinstance(hf_y, pd.Series):
+            if hasattr(hf_y, "values"):
                 # TODO: this line should not be needed here as we perform the
                 # parsing in the `parse_hf_data` function
                 s_v = hf_y.values
@@ -146,7 +146,9 @@ class PlotlyAggregatorParser:
         # View the data as an int64 when we have a DatetimeIndex
         # We only want to detect gaps, so we only want to compare values.
         agg_x_view = agg_x
-        if isinstance(agg_x, (pd.DatetimeIndex, pd.TimedeltaIndex)):
+        if np.issubdtype(agg_x.dtype, np.timedelta64) or np.issubdtype(
+            agg_x.dtype, np.datetime64
+        ):
             agg_x_view = agg_x.view("int64")
 
         agg_y, indices = downsampler.insert_none_at_gaps(agg_x_view, agg_y, indices)

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -454,7 +454,6 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
             This only works if the dash-app was started with :func:`show_dash`.
         """
         if self._app is not None:
-
             old_server = self._app._server_threads.get((self._host, self._port))
             if old_server:
                 old_server.kill()

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -286,17 +286,19 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             self._print("hf_data not found")
             return None
 
+        # Parse trace data (necessary when updating the trace data)
+        for k in ["x", "y"]:
+            if hasattr(hf_trace_data[k], "values"):
+                # when not a range index or datetime index
+                if not isinstance(hf_trace_data[k], (pd.RangeIndex, pd.DatetimeIndex)):
+                    hf_trace_data[k] = hf_trace_data[k].values
+
         # Also check if the y-data is empty, if so, return an empty trace
         if len(hf_trace_data["y"]) == 0:
             trace["x"] = []
             trace["y"] = []
             trace["name"] = hf_trace_data["name"]
             return trace
-
-        # We first check the traces to ensure that they are still arrays
-        PlotlyAggregatorParser.parse_hf_data(
-            hf_trace_data, ["x", "y", "text", "hovertext"]
-        )
 
         start_idx, end_idx = PlotlyAggregatorParser.get_start_end_indices(
             hf_trace_data, start, end

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -333,7 +333,6 @@ class AbstractFigureAggregator(BaseFigure, ABC):
                 assert isinstance(
                     hf_trace_data["downsampler"], DataPointSelector
                 ), "Only DataPointSelector can downsample non-data trace array props."
-                print("k_val", k_val)
                 trace[k] = k_val[start_idx + indices]
             elif k_val is not None:
                 trace[k] = k_val

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -198,7 +198,7 @@ def test_func_aggregator_categorical_time_data(cat_series):
     for n in np.random.randint(100, len(cat_series), 3):
         agg_x, agg_y = FuncAggregator(
             interleave_gaps=False, aggregation_func=cat_count
-        ).aggregate(cat_series.index.values, cat_series.values, n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.values.codes, n_out=n)
         assert not np.isnan(agg_y).any()
         assert len(agg_x) <= n + 1
 
@@ -212,7 +212,7 @@ def test_func_aggregator_invalid_input_data(cat_series):
     with pytest.raises(TypeError):
         FuncAggregator(
             interleave_gaps=True, aggregation_func=treat_string_as_numeric_data
-        ).aggregate(cat_series.index.values, cat_series.values, n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.to_numpy(), n_out=n)
 
 
 def test_funcAggregator_no_x():

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -198,7 +198,7 @@ def test_func_aggregator_categorical_time_data(cat_series):
     for n in np.random.randint(100, len(cat_series), 3):
         agg_x, agg_y = FuncAggregator(
             interleave_gaps=False, aggregation_func=cat_count
-        ).aggregate(cat_series.index.values, cat_series.values.to_numpy(), n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.values, n_out=n)
         assert not np.isnan(agg_y).any()
         assert len(agg_x) <= n + 1
 
@@ -212,12 +212,7 @@ def test_func_aggregator_invalid_input_data(cat_series):
     with pytest.raises(TypeError):
         FuncAggregator(
             interleave_gaps=True, aggregation_func=treat_string_as_numeric_data
-        ).aggregate(cat_series.index.values, cat_series.values.to_numpy(), n_out=n)
-
-    with pytest.raises(TypeError):
-        FuncAggregator(
-            interleave_gaps=True, aggregation_func=treat_string_as_numeric_data
-        ).aggregate(cat_series.index.values, cat_series.to_numpy(), n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.values, n_out=n)
 
 
 def test_funcAggregator_no_x():

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -35,7 +35,7 @@ from .utils import construct_index, wrap_aggregate
 def test_arg_downsample_no_x(series, downsampler, interleave_gaps):
     for n in np.random.randint(100, len(series), 6):
         indices = downsampler(interleave_gaps=interleave_gaps).arg_downsample(
-            y=series.values, n_out=n
+            series.values, n_out=n
         )
         assert len(indices) <= n + (n % 2)
 
@@ -58,7 +58,7 @@ def test_arg_downsample_x(series, downsampler, interleave_gaps, index_type):
     series.index = construct_index(series, index_type)
     for n in np.random.randint(100, len(series), 6):
         indices = downsampler(interleave_gaps=interleave_gaps).arg_downsample(
-            x=series.index, y=series.values, n_out=n
+            series.index.values, series.values, n_out=n
         )
         assert len(indices) <= n + (n % 2)
 
@@ -75,7 +75,7 @@ def test_arg_downsample_empty_series(downsampler, series, interleave_gaps, index
     series.index = construct_index(series, index_type)
     empty_series = series.iloc[0:0]
     idxs = downsampler(interleave_gaps=interleave_gaps).arg_downsample(
-        empty_series.index, empty_series.values, n_out=1_000
+        empty_series.index.values, empty_series.values, n_out=1_000
     )
     assert len(idxs) == 0
 
@@ -89,7 +89,7 @@ def test_arg_downsample_empty_series(downsampler, series, interleave_gaps, index
 def test_arg_downsample_no_x_empty_series(downsampler, series, interleave_gaps):
     empty_series = series.iloc[0:0]
     idxs = downsampler(interleave_gaps=interleave_gaps).arg_downsample(
-        y=empty_series.values, n_out=1_000
+        empty_series.values, n_out=1_000
     )
     assert len(idxs) == 0
 
@@ -169,7 +169,7 @@ def test_wrap_aggregate_x_gaps(downsampler, series):
 @pytest.mark.parametrize("agg_func", [np.mean])  # np.median, sum])
 @pytest.mark.parametrize("series", [lf("float_series"), lf("bool_series")])
 @pytest.mark.parametrize("interleave_gaps", [False, True])
-@pytest.mark.parametrize("index_type", ["float", "timedelta", "float", "int"])
+@pytest.mark.parametrize("index_type", ["datetime", "timedelta", "float", "int"])
 def test_func_aggregator_float_time_data(series, interleave_gaps, index_type, agg_func):
     # TIME indexed data -> resampled output should be same size as n_out
     series = series.copy()
@@ -198,7 +198,7 @@ def test_func_aggregator_categorical_time_data(cat_series):
     for n in np.random.randint(100, len(cat_series), 3):
         agg_x, agg_y = FuncAggregator(
             interleave_gaps=False, aggregation_func=cat_count
-        ).aggregate(cat_series.index, cat_series.values, n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.values.to_numpy(), n_out=n)
         assert not np.isnan(agg_y).any()
         assert len(agg_x) <= n + 1
 
@@ -206,18 +206,18 @@ def test_func_aggregator_categorical_time_data(cat_series):
 def test_func_aggregator_invalid_input_data(cat_series):
     # note: it is the user's responsibility to ensure that the input data is valid
     def treat_string_as_numeric_data(x):
-        return np.sum(x)
+        return np.mean(x)
 
     n = np.random.randint(100, len(cat_series) / 3)
     with pytest.raises(TypeError):
         FuncAggregator(
             interleave_gaps=True, aggregation_func=treat_string_as_numeric_data
-        ).aggregate(cat_series.index, cat_series.values, n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.values.to_numpy(), n_out=n)
 
     with pytest.raises(TypeError):
         FuncAggregator(
             interleave_gaps=True, aggregation_func=treat_string_as_numeric_data
-        ).aggregate(cat_series.index, cat_series, n_out=n)
+        ).aggregate(cat_series.index.values, cat_series.to_numpy(), n_out=n)
 
 
 def test_funcAggregator_no_x():
@@ -227,7 +227,7 @@ def test_funcAggregator_no_x():
 
     fa = FuncAggregator(np.mean, interleave_gaps=False)
     for n_out in np.random.randint(500, 1_000, size=3):
-        fa.aggregate(y=y, n_out=n_out)
+        fa.aggregate(y, n_out=n_out)
 
 
 # ------------------------------- MinMaxLTTB -------------------------------

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,6 +48,7 @@ def wrap_aggregate(
             "max_n_samples": n_out,
         }
     )
+    PlotlyAggregatorParser.parse_hf_data(hf_trace_data, ["x", "y"])
     return PlotlyAggregatorParser.aggregate(hf_trace_data, 0, len(hf_y))
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,7 +48,6 @@ def wrap_aggregate(
             "max_n_samples": n_out,
         }
     )
-    PlotlyAggregatorParser.parse_hf_data(hf_trace_data, ["x", "y"])
     return PlotlyAggregatorParser.aggregate(hf_trace_data, 0, len(hf_y))
 
 


### PR DESCRIPTION
This uses an identical interface as utilized in tsdownsample.

While reworking the interface I realized that the np array interface PR will result in a hard lock-in to the in-memory numpy arrays. To overcome this, we should be much more flexible in (1) what dataformats we support (np.array, pandas.Series, polars. …), and (2) how our data aggregation interoperates on that data (currently tsdownsample only works on numpy arrays -> requires converting other datat types to this :/ )