### PR TITLE
:sparkles: fix for #275

### DIFF
--- a/plotly_resampler/figure_resampler/assets/coarse_fine.js
+++ b/plotly_resampler/figure_resampler/assets/coarse_fine.js
@@ -90,7 +90,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             const layout_axis_anchors = getLayoutAxisAnchors(main_graphDiv.layout);
 
             // Use the maingraphDiv its layout to obtain a list of a list of all shared (x)axis names
-            // in practice, these are the xaxis names that are linked to each other (i.e. the inner list is the 
+            // in practice, these are the xaxis names that are linked to each other (i.e. the inner list is the
             // xaxis names of the subplot columns)
             // e.g.: [ [xaxis1, xaxis2],  [xaxis3, xaxis4] ]
             let shared_axes_list = _.chain(main_graphDiv.layout)
@@ -127,7 +127,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             };
 
             // iterate over the selected data range
-            console.log('selected data range', selectedData.range);
+            console.log("selected data range", selectedData.range);
             for (const anchor_key in selectedData.range) {
                 const selected_range = selectedData.range[anchor_key];
                 // Obtain the anchor key of the orthogonal axis (x or y), based on the coarse graphdiv anchor pairs
@@ -157,6 +157,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             Object.keys(relayout).length > 0 ? Plotly.relayout(main_graphDiv, relayout) : null;
             return mainFigID;
         },
+
         main_to_coarse: function (mainRelayout, coarseFigID, mainFigID) {
             const coarse_graphDiv = getGraphDiv(coarseFigID);
             const main_graphDiv = getGraphDiv(mainFigID);
@@ -179,6 +180,8 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                     y1: y_range[1],
                 };
             };
+
+            // console.log("main to coarse", mainRelayout);
 
             // Base case; no selections yet on the coarse graph
             if (!currentSelections) {
@@ -220,11 +223,9 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                 ) {
                     performed_update = true;
                     if (
-                        // mainRelayout[x_axis_key + ".showspikes"] === false &&
-                        // mainRelayout[y_axis_key + ".showspikes"] === false
-                        // NOTE: for some reason, showspikes info is only availabel for the xaxis & yaxis keys
-                        mainRelayout["xaxis.showspikes"] === false &&
-                        mainRelayout["yaxis.showspikes"] === false
+                        // NOTE: for some reason, showspikes info is only available for the xaxis & yaxis keys
+                        _.has(mainRelayout, "xaxis.showspikes") &&
+                        _.has(mainRelayout, "yaxis.showspikes")
                     ) {
                         // reset axis -> we use the coarse graphDiv layout
                         x_range = coarse_graphDiv.layout[x_axis_key].range;

--- a/plotly_resampler/figure_resampler/assets/coarse_fine.js
+++ b/plotly_resampler/figure_resampler/assets/coarse_fine.js
@@ -127,7 +127,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             };
 
             // iterate over the selected data range
-            console.log("selected data range", selectedData.range);
+            // console.log("selected data range", selectedData.range);
             for (const anchor_key in selectedData.range) {
                 const selected_range = selectedData.range[anchor_key];
                 // Obtain the anchor key of the orthogonal axis (x or y), based on the coarse graphdiv anchor pairs
@@ -181,13 +181,11 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                 };
             };
 
-            // console.log("main to coarse", mainRelayout);
-
             // Base case; no selections yet on the coarse graph
             if (!currentSelections) {
                 // if current selections is None
                 coarse_xy_axiskeys.forEach((xy_pair) => {
-                    console.log("xy pair", xy_pair);
+                    // console.log("xy pair", xy_pair);
                     const x_axis_key = _.has(layout_axis_anchors, xy_pair.y) ? layout_axis_anchors[xy_pair.y] : "xaxis";
                     const y_axis_key = _.has(layout_axis_anchors, xy_pair.x) ? layout_axis_anchors[xy_pair.x] : "yaxis";
                     // console.log('xaxis key', x_axis_key, main_graphDiv.layout[x_axis_key]);


### PR DESCRIPTION
Working example (clone this branch, run the code below in a notebook)


data: [data.csv](https://github.com/predict-idlab/plotly-resampler/files/13859945/data.csv)
code:
```Python
from plotly_resampler import register_plotly_resampler
import plotly.graph_objects as go

import pandas as pd

# NOTE: via the create_overview=True argument, we can create an rangeslider
register_plotly_resampler(mode="figure", create_overview=True, verbose=True)

df_hourly = pd.read_csv("data.csv", index_col=0)
hourly_fig = go.Figure()
hourly_fig.add_trace(
    go.Scatter(
        x=df_hourly["Date"],
        y=df_hourly["MWh"],
        name="Hourly position",
        mode="lines",
        showlegend=True,
    )
)
hourly_fig.update_layout(
    dragmode="pan",
    hovermode="x unified",
    # fmt: off
    # NOTE: call this after adding all traces
    # yaxis=dict(autorange=False),
    xaxis=dict(rangeselector=dict(buttons=list([
        dict(count=1, label="1 day", step="day", stepmode="backward"),
        dict(count=1, label="1 month", step="month", stepmode="backward"),
        dict(count=1, label="1 year", step="year", stepmode="backward"),
    ]))),
    # fmt: on
    template="plotly_white",
    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
)

hourly_fig.show_dash(mode="external")
```
output: ⬇️ 
![rangeselector](https://github.com/predict-idlab/plotly-resampler/assets/38005924/f4d41242-7b13-4bd8-b6f1-2b2096c45533)
