### PR TITLE
Address FutureWarning: 'H' is deprecated and will be removed in a future version. Please use 'h' instead of 'H'.

### DIFF
--- a/plotly_resampler/figure_resampler/utils.py
+++ b/plotly_resampler/figure_resampler/utils.py
@@ -173,7 +173,7 @@ def round_td_str(td: pd.Timedelta) -> str:
         [`timedelta_to_str`][figure_resampler.utils.timedelta_to_str]
 
     """
-    for t_s in ("D", "H", "min", "s", "ms", "us", "ns"):
+    for t_s in ("D", "h", "min", "s", "ms", "us", "ns"):
         if td > 0.95 * pd.Timedelta(f"1{t_s}"):
             return timedelta_to_str(td.round(t_s))
 


### PR DESCRIPTION
Noticed this FutureWarning when running plotly-resampler with pandas 2.2.0
```
<...>\Lib\site-packages\plotly_resampler\figure_resampler\utils.py:177: FutureWarning:
'H' is deprecated and will be removed in a future version. Please use 'h' instead of 'H'.
```
From what I can see lower case 'h' was required since pandas 1.0, so this change should not break compatibility with older pandas versions.

Let me know if you would prefer for me to open an issue before looking at this PR.