### PR TITLE
Update minmax operator image

### DIFF
--- a/plotly_resampler/aggregation/aggregators.py
+++ b/plotly_resampler/aggregation/aggregators.py
@@ -99,7 +99,7 @@ class MinMaxOverlapAggregator(DataPointSelector):
     """Aggregation method which performs binned min-max aggregation over 50% overlapping
     windows.
 
-    ![minmax operator image](https://github.com/predict-idlab/plotly-resampler/blob/main/docs/sphinx/_static/minmax_operator.png)
+    ![minmax operator image](https://github.com/predict-idlab/plotly-resampler/blob/main/mkdocs/static/minmax_operator.png)
 
     In the above image, **bin_size**: represents the size of *(len(series) / n_out)*.
     As the windows have 50% overlap and are consecutive, the min & max values are


### PR DESCRIPTION
# PR Summary
Commit e73cc8d98b8c00f0a1795fff0dc55a9e37ab4fae moved the location of `minmax_operator.png`. This PR adjusts sources to changes. Relevant page can be found [here](https://predict-idlab.github.io/plotly-resampler/v0.10.0/api/aggregation/aggregators/#aggregation.aggregators.MinMaxOverlapAggregator).