### PR TITLE
Fix: Add xaxis.range[0]/[1] If Not Exist

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -1299,6 +1299,23 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             # 1. Base case - there is an x-range specified in the front-end
             start_matches = self._re_matches(re.compile(r"xaxis\d*.range\[0]"), cl_k)
             stop_matches = self._re_matches(re.compile(r"xaxis\d*.range\[1]"), cl_k)
+
+            # When the user sets x range via update_xaxes and the number of points in
+            # data exceeds the default_n_shown_samples, then after resetting the axes
+            # the relayout may only have "xaxis.range", instead of "xaxis.range[0]" and
+            # "xaxis.range[1]". If this happens, we need to manually add "xaxis.range[0]"
+            # and "xaxis.range[1]", otherwise resetting axes wouldn't work.
+            if not (start_matches and stop_matches):
+                range_matches = self._re_matches(re.compile(r"xaxis\d*.range"), cl_k)
+                for range_match in range_matches:
+                    x_range = relayout_data[range_match]
+                    start, stop = x_range
+                    start_match = range_match + "[0]"
+                    stop_match = range_match + "[1]"
+                    relayout_data[start_match] = start
+                    relayout_data[stop_match] = stop
+                    start_matches.append(start_match)
+                    stop_matches.append(stop_match)
             if start_matches and stop_matches:  # when both are not empty
                 for t_start_key, t_stop_key in zip(start_matches, stop_matches):
                     # Check if the xaxis<NUMB> part of xaxis<NUMB>.[0-1] matches

--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
+++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
@@ -1300,6 +1300,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
             start_matches = self._re_matches(re.compile(r"xaxis\d*.range\[0]"), cl_k)
             stop_matches = self._re_matches(re.compile(r"xaxis\d*.range\[1]"), cl_k)
 
+            # related issue: https://github.com/predict-idlab/plotly-resampler/pull/336
             # When the user sets x range via update_xaxes and the number of points in
             # data exceeds the default_n_shown_samples, then after resetting the axes
             # the relayout may only have "xaxis.range", instead of "xaxis.range[0]" and
@@ -1316,6 +1317,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
                     relayout_data[stop_match] = stop
                     start_matches.append(start_match)
                     stop_matches.append(stop_match)
+                    del x_range, start, stop, start_match, stop_match
             if start_matches and stop_matches:  # when both are not empty
                 for t_start_key, t_stop_key in zip(start_matches, stop_matches):
                     # Check if the xaxis<NUMB> part of xaxis<NUMB>.[0-1] matches


### PR DESCRIPTION
Related PR #336 
Related issue: https://github.com/predict-idlab/plotly-resampler/issues/335 (which contains a thorough explanation)


Example to try:
```python
import numpy as np
import plotly.graph_objects as go
from plotly.subplots import make_subplots
from plotly_resampler import FigureResampler


time = 1000
N = 4001  # number of points in the subplot exceeds default_n_shown_samples
x = np.linspace(0.0, time, N, endpoint=False)
y = np.cos(1 / 2 * np.pi + 2 / 50 * np.pi * x)

fig = FigureResampler(make_subplots(rows=2, cols=1), verbose=True)

fig.add_trace(go.Scattergl(), hf_x=x, hf_y=y, row=1, col=1)

fig.add_trace(go.Scattergl(), hf_x=x, hf_y=-y, row=2, col=1)

fig.update_xaxes(
    range=[0, np.ceil(x[-1])],  # set the x range of the subplot
    row=1,
    col=1,
)

fig.update_xaxes(
    range=[0, np.ceil(x[-1])],  # set the x range of the subplot
    row=2,
    col=1,
)
fig.show_dash(config={"scrollZoom": True})
```