### PR TITLE
Fix: Import JupyterDashPersistentInlineOutput only when needed

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -625,7 +625,10 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         # function signatures are slightly different for the (Jupyter)Dash and the
         # JupyterDashInlinePersistent implementations
         if mode == "inline_persistent":
-            from .jupyter_dash_persistent_inline_output import JupyterDashPersistentInlineOutput
+            from .jupyter_dash_persistent_inline_output import (
+                JupyterDashPersistentInlineOutput,
+            )
+
             jpi = JupyterDashPersistentInlineOutput(self)
             jpi.run_app(app=app, **kwargs)
         else:

--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -26,7 +26,6 @@ from ..aggregation import (
     MinMaxLTTB,
 )
 from .figure_resampler_interface import AbstractFigureAggregator
-from .jupyter_dash_persistent_inline_output import JupyterDashPersistentInlineOutput
 from .utils import is_figure, is_fr
 
 # Default arguments for the Figure overview
@@ -626,6 +625,7 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         # function signatures are slightly different for the (Jupyter)Dash and the
         # JupyterDashInlinePersistent implementations
         if mode == "inline_persistent":
+            from .jupyter_dash_persistent_inline_output import JupyterDashPersistentInlineOutput
             jpi = JupyterDashPersistentInlineOutput(self)
             jpi.run_app(app=app, **kwargs)
         else:

--- a/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
+++ b/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
@@ -12,9 +12,14 @@ import requests
 try:
     from IPython.display import HTML, display
 except ImportError:
-    pass
+    raise ImportError(
+        "The `jupyter_dash_persistent_inline_output` module is not installed.\n"
+        "Please install it with:\n"
+        "pip install plotly_resampler[inline_persistent]"
+    )
 
-from dash._jupyter import JupyterDash, _jupyter_config, make_server, retry
+from dash._jupyter import JupyterDash, _jupyter_config, make_server
+from retrying import retry
 from plotly.graph_objects import Figure
 
 

--- a/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
+++ b/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
@@ -13,8 +13,8 @@ try:
     from IPython.display import HTML, display
 except ImportError:
     raise ImportError(
-        "The `jupyter_dash_persistent_inline_output` module is not installed.\n"
-        "Please install it with:\n"
+        "The `jupyter_dash_persistent_inline_output` requirements are not installed.\n"
+        "Please install them with:\n"
         "pip install plotly_resampler[inline_persistent]"
     )
 

--- a/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
+++ b/plotly_resampler/figure_resampler/jupyter_dash_persistent_inline_output.py
@@ -19,8 +19,8 @@ except ImportError:
     )
 
 from dash._jupyter import JupyterDash, _jupyter_config, make_server
-from retrying import retry
 from plotly.graph_objects import Figure
+from retrying import retry
 
 
 class JupyterDashPersistentInlineOutput:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4638,4 +4638,4 @@ inline-persistent = ["Flask-Cors", "kaleido"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "bf8da9973219056e0024011f3941f2872873a2360864ddfc33704661278f5226"
+content-hash = "730db5e71acdc1e74dbc68897f71ea223ebe31f877b6b83bdcffe97f60431cd3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ tsdownsample = ">=0.1.3"
 
 [tool.poetry.extras]
 # Optional dependencies
-inline_persistent = ["kaleido", "Flask-Cors"]
+inline_persistent = ["kaleido", "Flask-Cors", "ipython"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -1279,7 +1279,7 @@ def test_manual_jupyterdashpersistentinline():
 
     import dash
 
-    from plotly_resampler.figure_resampler.figure_resampler import (
+    from plotly_resampler.figure_resampler.jupyter_dash_persistent_inline_output import (
         JupyterDashPersistentInlineOutput,
     )
 


### PR DESCRIPTION
Related: #348