### PR TITLE
Fix: Default Mode In show_dash Causes TypeError

### DIFF
--- a/plotly_resampler/figure_resampler/figure_resampler.py
+++ b/plotly_resampler/figure_resampler/figure_resampler.py
@@ -530,9 +530,9 @@ class FigureResampler(AbstractFigureAggregator, go.Figure):
         available_modes = list(dash._jupyter.JupyterDisplayMode.__args__) + [
             "inline_persistent"
         ]
-        assert (
-            mode is None or mode in available_modes
-        ), f"mode must be one of {available_modes}"
+        if mode is None:
+            mode = "external"
+        assert mode in available_modes, f"mode must be one of {available_modes}"
         graph_properties = {} if graph_properties is None else graph_properties
         assert "config" not in graph_properties  # There is a param for config
         if self["layout"]["autosize"] is True and self["layout"]["height"] is None:

--- a/tests/test_figure_resampler.py
+++ b/tests/test_figure_resampler.py
@@ -2024,3 +2024,11 @@ def test_manual_range_def(shared_xaxes):
     assert isinstance(ud, list) and len(ud) == 2
     ud = fig._construct_update_data({"xaxis2.range": [2, 10], "xaxis.range": [5, 100]})
     assert isinstance(ud, list) and len(ud) == 3
+
+
+def test_show_dash_with_default_mode():
+    x = np.arange(100)
+    y = np.sin(x)
+    fig = FigureResampler(go.Figure())
+    fig.add_trace(go.Scattergl(), hf_x=x, hf_y=y)
+    fig.show_dash(config={"scrollZoom": True})  # mode defaults to None


### PR DESCRIPTION
This pull request aims to address the following bug.

**Describe the bug** :crayon:
When calling `FigureResampler.show_dash()` without specifying mode, the method raises `TypeError: argument of type 'NoneType' is not iterable`. Full error message is
```python
TypeError                                 Traceback (most recent call last)
File c:\users\yzhao\python_projects\plotly-resampler\tests\test_show_dash.py:19
     16 fig = FigureResampler(go.Figure())
     17 fig.add_trace(go.Scattergl(), hf_x=x, hf_y=y)
---> 19 fig.show_dash(config={"scrollZoom": True})  # mode defaults to None

File ~\python_projects\plotly-resampler\plotly_resampler\figure_resampler\figure_resampler.py:610, in FigureResampler.show_dash(self, mode, config, init_dash_kwargs, graph_properties, **kwargs)
    608 # 2. Run the app
    609 height_param = "height" if mode == "inline_persistent" else "jupyter_height"
--> 610 if "inline" in mode and height_param not in kwargs:
    611     # If app height is not specified -> re-use figure height for inline dash app
    612     #  Note: default layout height is 450 (whereas default app height is 650)
    613     #  See: https://plotly.com/python/reference/layout/#layout-height
    614     fig_height = self.layout.height if self.layout.height is not None else 450
    615     kwargs[height_param] = fig_height + 18

TypeError: argument of type 'NoneType' is not iterable
```

**Reproducing the bug** :mag:
```python
import numpy as np
import plotly.graph_objects as go
from plotly_resampler import FigureResampler


x = np.arange(100)
y = np.sin(x)

fig = FigureResampler(go.Figure())
fig.add_trace(go.Scattergl(), hf_x=x, hf_y=y)

fig.show_dash(config={"scrollZoom": True})  # mode defaults to None
```

**Expected behavior**  :wrench:
The figure opens in "external" mode, according to the [`show_dash`](https://github.com/predict-idlab/plotly-resampler/blob/main/plotly_resampler/figure_resampler/figure_resampler.py#L465) docstring.


**Environment information**: (please complete the following information)
- OS: Windows 11
- Python environment: 
  - Python version: 3.12
   - plotly-resampler environment: e.g.:  Dash web app (Chrome)
- plotly-resampler version: 0.11.0


**Additional context**
The cause of the error is in the line [`if "inline" in mode and height_param not in kwargs:` ](https://github.com/predict-idlab/plotly-resampler/blob/94833263ccc089fd31f328c79dc283a2cd920f36/plotly_resampler/figure_resampler/figure_resampler.py#L610), which doesn't work when `mode` defaults to `None` but is regarded as a string here. We can fix this by setting `mode` to "external" before this line.